### PR TITLE
Support sferik/twitter's deprecation of entity[:indices]

### DIFF
--- a/rb/lib/twitter-text/rewriter.rb
+++ b/rb/lib/twitter-text/rewriter.rb
@@ -5,13 +5,17 @@ module Twitter
       chars = text.to_s.to_char_a
 
       # sort by start index
-      entities = entities.sort_by{|entity| entity[:indices].first}
+      entities = entities.sort_by do |entity|
+        indices = entity.respond_to?(:indices) ? entity.indices : entity[:indices]
+        indices.first
+      end
 
       result = []
       last_index = entities.inject(0) do |index, entity|
-        result << chars[index...entity[:indices].first]
+        indices = entity.respond_to?(:indices) ? entity.indices : entity[:indices]
+        result << chars[index...indices.first]
         result << yield(entity, chars)
-        entity[:indices].last
+        indices.last
       end
       result << chars[last_index..-1]
 


### PR DESCRIPTION
Accessing a property via an indexer was deprecated in sferik's twitter gem here: https://github.com/sferik/twitter/commit/2ab6c0d546b7c1d3635ac9c319fb5c2aa2514da0.

In our code base, we use the twitter-text gem to rewrite tweets, passing in entities initialized via sferik's twitter gem. This is now causing a lot of deprecation warnings throughout our logs:

```
/home/rof/cache/bundler/ruby/2.1.0/gems/twitter-text-1.10.0/lib/twitter-text/rewriter.rb:12:in `block in rewrite_entities': [DEPRECATION] #[:indices] is deprecated. Use #indices to fetch the value.
/home/rof/cache/bundler/ruby/2.1.0/gems/twitter-text-1.10.0/lib/twitter-text/rewriter.rb:14:in `block in rewrite_entities': [DEPRECATION] #[:indices] is deprecated. Use #indices to fetch the value.
/home/rof/cache/bundler/ruby/2.1.0/gems/twitter-text-1.10.0/lib/twitter-text/rewriter.rb:8:in `block in rewrite_entities': [DEPRECATION] #[:indices] is deprecated. Use #indices to fetch the value.
```

As a simple fix, I updated the code to check and see if the entity respond_to?(:indices) is true and if so use the method. Otherwise, fall back to using the index accessor.