### PR TITLE
Update pod spec to reference unified git repo location

### DIFF
--- a/objc/twitter-text.podspec
+++ b/objc/twitter-text.podspec
@@ -1,16 +1,17 @@
 Pod::Spec.new do |s|
-  name = "twitter-text-objc"
+  name = "twitter-text"
   version = "1.11.0"
   url = "https://github.com/twitter/#{name}"
   git_url = "#{url}.git"
+  tag = "v#{version}"
 
   s.name = name
   s.version = version
   s.license = { :type => "Apache License, Version 2.0" }
   s.summary = "Objective-C port of the twitter-text handling libraries."
-  s.homepage = url
-  s.source = { :git => "https://github.com/twitter/twitter-text-objc.git", :tag => "v#{s.version}" }
-  s.source_files = "lib/**/*.{h,m}"
+  s.homepage = "#{url}/tree/#{tag}/objc"
+  s.source = { :git => "#{url}.git", :tag => tag }
+  s.source_files = "objc/lib/**/*.{h,m}"
   s.author = { "Twitter, Inc." => "opensource@twitter.com" }
   s.ios.deployment_target = "4.0"
   s.osx.deployment_target = "10.7"


### PR DESCRIPTION
The existing podpec references https://github.com/twitter/twitter-text-objc which doesn't include the latest version tags.