### PR TITLE
Ruby bugfix for autolinking RTL hashtags with :hashtag_class => nil

### DIFF
--- a/rb/lib/twitter-text/autolink.rb
+++ b/rb/lib/twitter-text/autolink.rb
@@ -329,10 +329,10 @@ module Twitter
       hash = chars[entity[:indices].first]
       hashtag = entity[:hashtag]
       hashtag = yield(hashtag) if block_given?
-      hashtag_class = options[:hashtag_class]
+      hashtag_class = options[:hashtag_class].to_s
 
       if hashtag.match Twitter::Regex::REGEXEN[:rtl_chars]
-        (hashtag_class ||= '') << ' rtl'
+        hashtag_class += ' rtl'
       end
 
       href = if options[:hashtag_url_block]

--- a/rb/lib/twitter-text/autolink.rb
+++ b/rb/lib/twitter-text/autolink.rb
@@ -332,7 +332,7 @@ module Twitter
       hashtag_class = options[:hashtag_class]
 
       if hashtag.match Twitter::Regex::REGEXEN[:rtl_chars]
-        hashtag_class += ' rtl'
+        (hashtag_class ||= '') << ' rtl'
       end
 
       href = if options[:hashtag_url_block]


### PR DESCRIPTION
This fixes a bug I was seeing when I passed the option `hashtag_class: nil` to the `auto_link` method with a hebrew hashtag as the argument (hebrew is written from right to left):

```
[Dev]> Twitter::Autolink.auto_link("#ביתכנסת #קופנהגן", hashtag_class: nil)
NoMethodError: undefined method `+' for nil:NilClass
```

The change is to make sure the variable `hashtag_class` is a string before we try to append `' rtl'` to it. Same example with the changes works as expected:

```
[Dev]> Twitter::Autolink.auto_link("#ביתכנסת #קופנהגן", hashtag_class: nil)
=> "<a class=\" rtl\" href=\"https://twitter.com/#!/search?q=%23ביתכנסת\" rel=\"nofollow\" title=\"#ביתכנסת\">#ביתכנסת</a> <a class=\" rtl\" href=\"https://twitter.com/#!/search?q=%23קופנהגן\" rel=\"nofollow\" title=\"#קופנהגן\">#קופנהגן</a>"
```