### PR TITLE
Revert "Export to global scope in server or embedded environments"

### DIFF
--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -1,4 +1,4 @@
-(function(__global__) {
+(function() {
   if (typeof twttr === "undefined" || twttr === null) {
     var twttr = {};
   }
@@ -1326,13 +1326,13 @@
     define([], twttr.txt);
   }
 
-
-  if (__global__.twttr) {
-    for (var prop in twttr) {
-      __global__.twttr[prop] = twttr[prop];
+  if (typeof window != 'undefined') {
+    if (window.twttr) {
+      for (var prop in twttr) {
+        window.twttr[prop] = twttr[prop];
+      }
+    } else {
+      window.twttr = twttr;
     }
-  } else {
-    __global__.twttr = twttr;
   }
-
-})(this);
+})();


### PR DESCRIPTION
This reverts commit aae2099e8426922af269adde9e064e70511dbe77.
  aae2099 was originally merged by be92738a1a928

While this change passes tests, it breaks twitter.com with:
"Uncaught TypeError: undefined is not a function"

Hopefully those who need this can maintain their own fork for now.
/cc @jeroenooms