### PR TITLE
Return @mentions preceeded by @

### DIFF
--- a/conformance/extract.yml
+++ b/conformance/extract.yml
@@ -70,7 +70,7 @@ tests:
 
     - description: "DO NOT extract username preceded by @"
       text: "f@@kn"
-      expected: []
+      expected: ['kn']
 
     - description: "DO NOT extract username preceded by #"
       text: "f#@kn"

--- a/java/src/com/twitter/Regex.java
+++ b/java/src/com/twitter/Regex.java
@@ -157,7 +157,7 @@ public class Regex {
   public static final Pattern RTL_CHARACTERS = Pattern.compile("[\u0600-\u06FF\u0750-\u077F\u0590-\u05FF\uFE70-\uFEFF]");
 
   public static final Pattern AT_SIGNS = Pattern.compile("[" + AT_SIGNS_CHARS + "]");
-  public static final Pattern VALID_MENTION_OR_LIST = Pattern.compile("([^a-z0-9_!#$%&*" + AT_SIGNS_CHARS + "]|^|RT:?)(" + AT_SIGNS + "+)([a-z0-9_]{1,20})(/[a-z][a-z0-9_\\-]{0,24})?", Pattern.CASE_INSENSITIVE);
+  public static final Pattern VALID_MENTION_OR_LIST = Pattern.compile("([^a-z0-9_!#$%&*]|^|RT:?)(" + AT_SIGNS + "+)([a-z0-9_]{1,20})(/[a-z][a-z0-9_\\-]{0,24})?", Pattern.CASE_INSENSITIVE);
   public static final int VALID_MENTION_OR_LIST_GROUP_BEFORE = 1;
   public static final int VALID_MENTION_OR_LIST_GROUP_AT = 2;
   public static final int VALID_MENTION_OR_LIST_GROUP_USERNAME = 3;

--- a/java/tests/com/twitter/RegexTest.java
+++ b/java/tests/com/twitter/RegexTest.java
@@ -113,8 +113,15 @@ public class RegexTest extends TestCase {
     assertCaptureCount(4, Regex.VALID_MENTION_OR_LIST, "sample @user mention");
   }
 
+  public void testValidMentions() {
+    char[] valid_chars = new char[]{'@'};
+    for (char c : valid_chars) {
+      assertTrue("Failed to capture a mention preceded by " + c, Regex.VALID_MENTION_OR_LIST.matcher("f" + c + "@kn").find());
+    }
+  }
+
   public void testInvalidMentions() {
-    char[] invalid_chars = new char[]{'!', '@', '#', '$', '%', '&', '*'};
+    char[] invalid_chars = new char[]{'!', '#', '$', '%', '&', '*'};
     for (char c : invalid_chars) {
       assertFalse("Failed to ignore a mention preceded by " + c, Regex.VALID_MENTION_OR_LIST.matcher("f" + c + "@kn").find());
     }

--- a/js/test/tests.js
+++ b/js/test/tests.js
@@ -293,11 +293,20 @@ test("twttr.txt.linkTextWithEntity", function() {
 });
 
 test("twttr.txt.extractMentionsOrListsWithIndices", function() {
-  var invalid_chars = ['!', '@', '#', '$', '%', '&', '*'];
+  var invalid_chars = ['!', '#', '$', '%', '&', '*'];
 
   for (var i = 0; i < invalid_chars.length; i++) {
     c = invalid_chars[i];
     equal(twttr.txt.extractMentionsOrListsWithIndices("f" + c + "@kn").length, 0, "Should not extract mention if preceded by " + c);
+  }
+});
+
+test("twttr.txt.extractMentionsOrListsWithIndices", function() {
+  var valid_chars = ['@'];
+
+  for (var i = 0; i < valid_chars.length; i++) {
+    c = valid_chars[i];
+    equal(twttr.txt.extractMentionsOrListsWithIndices("f" + c + "@kn").length, 1, "Should not extract mention if preceded by " + c);
   }
 });
 

--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -141,7 +141,7 @@
   twttr.txt.regexen.validHashtag = regexSupplant(/(#{hashtagBoundary})(#{hashSigns})(#{hashtagAlphaNumeric}*#{hashtagAlpha}#{hashtagAlphaNumeric}*)/gi);
 
   // Mention related regex collection
-  twttr.txt.regexen.validMentionPrecedingChars = /(?:^|[^a-zA-Z0-9_!#$%&*@＠]|(?:rt|RT|rT|Rt):?)/;
+  twttr.txt.regexen.validMentionPrecedingChars = /(?:^|[^a-zA-Z0-9_!#$%&*]|(?:rt|RT|rT|Rt):?)/;
   twttr.txt.regexen.atSigns = /[@＠]/;
   twttr.txt.regexen.validMentionOrList = regexSupplant(
     '(#{validMentionPrecedingChars})' +  // $1: Preceding character

--- a/rb/lib/twitter-text/regex.rb
+++ b/rb/lib/twitter-text/regex.rb
@@ -114,7 +114,7 @@ module Twitter
     # Used in Extractor for final filtering
     REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
 
-    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_!#\$%&*@＠]|^|[rR][tT]:?)/o
+    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_!#\$%&*]|^|[rR][tT]:?)/o
     REGEXEN[:at_signs] = /[@＠]/
     REGEXEN[:valid_mention_or_list] = /
       (#{REGEXEN[:valid_mention_preceding_chars]})  # $1: Preceeding character

--- a/rb/spec/extractor_spec.rb
+++ b/rb/spec/extractor_spec.rb
@@ -40,10 +40,17 @@ describe Twitter::Extractor do
         @extractor.extract_mentioned_screen_names("の@aliceに到着を待っている").should == ["alice"]
       end
 
-      it "should ignore mentions preceded by !, @, #, $, %, & or *" do
-        invalid_chars = ['!', '@', '#', '$', '%', '&', '*']
+      it "should ignore mentions preceded by !, #, $, %, & or *" do
+        invalid_chars = ['!', '#', '$', '%', '&', '*']
         invalid_chars.each do |c|
           @extractor.extract_mentioned_screen_names("f#{c}@kn").should == []
+        end
+      end
+
+      it "should accept mentions preceded by @ or ＠" do
+        valid_chars = ['@', '＠']
+        valid_chars.each do |c|
+          @extractor.extract_mentioned_screen_names("f#{c}@kn").should == ['kn']
         end
       end
     end


### PR DESCRIPTION
Such as @@kn
These changes bring the library into alignment with the actual Twitter
website and API as shown here:
https://twitter.com/StreetGeekEnt/statuses/554800426768277504
https://twitter.com/kung_fu_mike/status/570024458640973824

This commit only fixes the Ruby, Java, and JavaScript Libraries. I
don't have an environment for Objective C development.
