### PR TITLE
Don't linkify RT@example when common email chars precede the RT

### DIFF
--- a/conformance/autolink.yml
+++ b/conformance/autolink.yml
@@ -36,6 +36,14 @@ tests:
       text: "RT@username: long Tweet is loooong"
       expected: "RT@<a class=\"tweet-url username\" href=\"https://twitter.com/username\">username</a>: long Tweet is loooong"
 
+    - description: "Autolink alternate RT format in middle of text"
+      text: "Check out RT:@username yas"
+      expected: "Check out RT:@<a class=\"tweet-url username\" href=\"https://twitter.com/username\">username</a> yas"
+
+    - description: "DO NOT Autolink domain of email address ending in RT like support@example.com"
+      text: "Email support@example.com"
+      expected: "Email support@example.com"
+
     - description: "DO NOT Autolink username followed by accented latin characters"
       text: "@aliceìnheiro something something"
       expected: "@aliceìnheiro something something"

--- a/java/src/com/twitter/Regex.java
+++ b/java/src/com/twitter/Regex.java
@@ -206,7 +206,7 @@ public class Regex {
       INVALID_HASHTAG_MATCH_END = Pattern.compile("^(?:[#＃]|://)");
       RTL_CHARACTERS = Pattern.compile("[\u0600-\u06FF\u0750-\u077F\u0590-\u05FF\uFE70-\uFEFF]");
       AT_SIGNS = Pattern.compile("[" + AT_SIGNS_CHARS + "]");
-      VALID_MENTION_OR_LIST = Pattern.compile("([^a-z0-9_!#$%&*" + AT_SIGNS_CHARS + "]|^|RT:?)(" + AT_SIGNS + "+)([a-z0-9_]{1,20})(/[a-z][a-z0-9_\\-]{0,24})?", Pattern.CASE_INSENSITIVE);
+      VALID_MENTION_OR_LIST = Pattern.compile("([^a-z0-9_!#$%&*" + AT_SIGNS_CHARS + "]|^|(?:^|[^a-z0-9_+~.-])RT:?)(" + AT_SIGNS + "+)([a-z0-9_]{1,20})(/[a-z][a-z0-9_\\-]{0,24})?", Pattern.CASE_INSENSITIVE);
       VALID_REPLY = Pattern.compile("^(?:" + UNICODE_SPACES + ")*" + AT_SIGNS + "([a-z0-9_]{1,20})", Pattern.CASE_INSENSITIVE);
       INVALID_MENTION_MATCH_END = Pattern.compile("^(?:[" + AT_SIGNS_CHARS + LATIN_ACCENTS_CHARS + "]|://)");
       INVALID_URL_WITHOUT_PROTOCOL_MATCH_BEGIN = Pattern.compile("[-_./]$");

--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -141,7 +141,7 @@
   twttr.txt.regexen.validHashtag = regexSupplant(/(#{hashtagBoundary})(#{hashSigns})(#{hashtagAlphaNumeric}*#{hashtagAlpha}#{hashtagAlphaNumeric}*)/gi);
 
   // Mention related regex collection
-  twttr.txt.regexen.validMentionPrecedingChars = /(?:^|[^a-zA-Z0-9_!#$%&*@＠]|(?:rt|RT|rT|Rt):?)/;
+  twttr.txt.regexen.validMentionPrecedingChars = /(?:^|[^a-zA-Z0-9_!#$%&*@＠]|(?:^|[^a-zA-Z0-9_+~.-])(?:rt|RT|rT|Rt):?)/;
   twttr.txt.regexen.atSigns = /[@＠]/;
   twttr.txt.regexen.validMentionOrList = regexSupplant(
     '(#{validMentionPrecedingChars})' +  // $1: Preceding character

--- a/objc/lib/TwitterText.m
+++ b/objc/lib/TwitterText.m
@@ -88,7 +88,7 @@
 // Mention and list name
 //
 
-#define TWUValidMentionPrecedingChars   @"(?:[^a-zA-Z0-9_!#$%&*@＠]|^|RT:?)"
+#define TWUValidMentionPrecedingChars   @"(?:[^a-zA-Z0-9_!#$%&*@＠]|^|(?:^|[^a-zA-Z0-9_+~.-])RT:?)"
 #define TWUAtSigns                      @"[@＠]"
 #define TWUValidUsername                @"\\A" TWUAtSigns @"[a-zA-Z0-9_]{1,20}\\z"
 #define TWUValidList                    @"\\A" TWUAtSigns @"[a-zA-Z0-9_]{1,20}/[a-zA-Z][a-zA-Z0-9_\\-]{0,24}\\z"

--- a/rb/lib/twitter-text/regex.rb
+++ b/rb/lib/twitter-text/regex.rb
@@ -114,7 +114,7 @@ module Twitter
     # Used in Extractor for final filtering
     REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
 
-    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_!#\$%&*@＠]|^|[rR][tT]:?)/o
+    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_!#\$%&*@＠]|^|(?:^|[^a-zA-Z0-9_+~.-])[rR][tT]:?)/o
     REGEXEN[:at_signs] = /[@＠]/
     REGEXEN[:valid_mention_or_list] = /
       (#{REGEXEN[:valid_mention_preceding_chars]})  # $1: Preceeding character


### PR DESCRIPTION
support@example.com should not link @example
rt@example should link @example