### PR TITLE
adding trailing hyphen to valid url query endings

### DIFF
--- a/rb/lib/twitter-text/regex.rb
+++ b/rb/lib/twitter-text/regex.rb
@@ -208,7 +208,7 @@ module Twitter
     )/iox
 
     REGEXEN[:valid_url_query_chars] = /[a-z0-9!?\*'\(\);:&=\+\$\/%#\[\]\-_\.,~|@]/i
-    REGEXEN[:valid_url_query_ending_chars] = /[a-z0-9_&=#\/]/i
+    REGEXEN[:valid_url_query_ending_chars] = /[a-z0-9_&=#\/\-]/i
     REGEXEN[:valid_url] = %r{
       (                                                                                     #   $1 total match
         (#{REGEXEN[:valid_url_preceding_chars]})                                            #   $2 Preceeding chracter

--- a/rb/spec/test_urls.rb
+++ b/rb/spec/test_urls.rb
@@ -35,7 +35,8 @@ module TestUrls
     "t.co/nwcLTFF",
     "http://foobar.みんな",
     "http://foobar.中国",
-    "http://foobar.پاکستان"
+    "http://foobar.پاکستان",
+    "https://www.youtube.com/playlist?list=PL0ZPu8XSRTB7wZzn0mLHMvyzVFeRxbWn-"
   ] unless defined?(TestUrls::VALID)
 
   INVALID = [


### PR DESCRIPTION
URLs that end with a hyphen such as https://www.youtube.com/playlist?list=PL0ZPu8XSRTB7wZzn0mLHMvyzVFeRxbWn- should be valid.