### PR TITLE
Do not alter arguments passed to Twitter::Autolink methods

### DIFF
--- a/rb/lib/twitter-text/autolink.rb
+++ b/rb/lib/twitter-text/autolink.rb
@@ -232,7 +232,8 @@ module Twitter
     def url_entities_hash(url_entities)
       (url_entities || {}).inject({}) do |entities, entity|
         # be careful not to alter arguments received
-        entities[entity[:url]] = HashHelper.symbolize_keys(entity)
+        _entity = HashHelper.symbolize_keys(entity)
+        entities[_entity[:url]] = _entity
         entities
       end
     end

--- a/rb/lib/twitter-text/autolink.rb
+++ b/rb/lib/twitter-text/autolink.rb
@@ -47,10 +47,12 @@ module Twitter
       entities = json.values().flatten()
 
       # map JSON entity to twitter-text entity
-      entities.each do |entity|
-        HashHelper.symbolize_keys!(entity)
+      # be careful not to alter arguments received
+      entities.map! do |entity|
+        entity = HashHelper.symbolize_keys(entity)
         # hashtag
         entity[:hashtag] = entity[:text] if entity[:text]
+        entity
       end
 
       auto_link_entities(text, entities, options)
@@ -229,8 +231,8 @@ module Twitter
 
     def url_entities_hash(url_entities)
       (url_entities || {}).inject({}) do |entities, entity|
-        HashHelper.symbolize_keys!(entity)
-        entities[entity[:url]] = entity
+        # be careful not to alter arguments received
+        entities[entity[:url]] = HashHelper.symbolize_keys(entity)
         entities
       end
     end

--- a/rb/lib/twitter-text/hash_helper.rb
+++ b/rb/lib/twitter-text/hash_helper.rb
@@ -6,7 +6,7 @@ module Twitter
     #   { 'name' => 'Rob', 'years' => '28' }.symbolize_keys
     #   #=> { :name => "Rob", :years => "28" }
     def self.symbolize_keys(hash)
-      hash.dup.symbolize_keys!
+      symbolize_keys!(hash.dup)
     end
 
     # Destructively convert all keys to symbols, as long as they respond


### PR DESCRIPTION
By using the 'destructive' symbolize_keys! method, the caller gets an unexpected behaviour
where the arguments passed are modified by the Autolink methods. This side-effect is better
to avoid in general.

BTW, fix the non-destructive symbolize_keys method.

All conformances tests are still OK.