### PR TITLE
Added Javascript unit tests for twttr.txt.getTweetLength

### DIFF
--- a/js/test/tests.js
+++ b/js/test/tests.js
@@ -307,3 +307,10 @@ test("twttr.txt.extractUrls", function() {
   equal(twttr.txt.extractUrls(message_with_hyphenated_url)[0], "hyphenated-url.com", "Should extract full url with hyphen.");
   equal(twttr.txt.extractUrls(message_with_www_hyphenated_url)[0], "www.123-hyphenated-url.com", "Should extract full url with hyphen.");
 });
+
+test("twttr.txt.getTweetLength", function() {
+  equal(twttr.txt.getTweetLength(""), 0, "empty should be zero length.");
+  equal(twttr.txt.getTweetLength("sample tweet"), 12, "Should extract full url with hyphen.");
+  equal(twttr.txt.getTweetLength("sample tweet with short url http://t.co/1"), 51, "Should count short URLs as 23");
+  equal(twttr.txt.getTweetLength("sample tweet with short url http://t.co/this_is_really_really_really_really_really_long"), 94, "Should count long URLs as 23");
+});

--- a/js/test/tests.js
+++ b/js/test/tests.js
@@ -310,7 +310,7 @@ test("twttr.txt.extractUrls", function() {
 
 test("twttr.txt.getTweetLength", function() {
   equal(twttr.txt.getTweetLength(""), 0, "empty should be zero length.");
-  equal(twttr.txt.getTweetLength("sample tweet"), 12, "Should extract full url with hyphen.");
+  equal(twttr.txt.getTweetLength("sample tweet"), 12, "small tweet should be counted correctly.");
   equal(twttr.txt.getTweetLength("sample tweet with short url http://t.co/1"), 51, "Should count short URLs as 23");
   equal(twttr.txt.getTweetLength("sample tweet with short url http://t.co/this_is_really_really_really_really_really_long"), 94, "Should count long URLs as 23");
 });


### PR DESCRIPTION
I had to do some testing on the getTweetLength javascript function for a defect in my own system. 
In the process I wrote some unit tests to confirm my own assumptions about how getTweetLength behaved with long URLs. 
Hopefully you find the unit tests useful as well. 