### PR TITLE
JS: Properly convert indices for duplicate entities

### DIFF
--- a/js/test/tests.js
+++ b/js/test/tests.js
@@ -307,3 +307,15 @@ test("twttr.txt.extractUrls", function() {
   equal(twttr.txt.extractUrls(message_with_hyphenated_url)[0], "hyphenated-url.com", "Should extract full url with hyphen.");
   equal(twttr.txt.extractUrls(message_with_www_hyphenated_url)[0], "www.123-hyphenated-url.com", "Should extract full url with hyphen.");
 });
+
+test("twttr.txt.convertUnicodeIndices", function () {
+  var entities = [
+    { indices: [32, 50] },
+    { indices: [32, 50] }
+  ];
+  twttr.txt.convertUnicodeIndices("Message with multiple photos \uD801\uDC00 http://t.co/foobar", entities);
+  deepEqual(entities, [
+    { indices: [33, 51] },
+    { indices: [33, 51] }
+  ]);
+});

--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -1041,19 +1041,22 @@
           break;
         }
         entity = entities[entityIndex];
-      }
 
-      var c = text.charCodeAt(charIndex);
-      if (0xD800 <= c && c <= 0xDBFF && charIndex < text.length - 1) {
-        // Found high surrogate char
-        c = text.charCodeAt(charIndex + 1);
-        if (0xDC00 <= c && c <= 0xDFFF) {
-          // Found surrogate pair
-          charIndex++;
+        // There may be overalapping media entities with the same start index,
+        // so don't move the codePointIndex or charIndex on this pass.
+      } else {
+        var c = text.charCodeAt(charIndex);
+        if (0xD800 <= c && c <= 0xDBFF && charIndex < text.length - 1) {
+          // Found high surrogate char
+          c = text.charCodeAt(charIndex + 1);
+          if (0xDC00 <= c && c <= 0xDFFF) {
+            // Found surrogate pair
+            charIndex++;
+          }
         }
+        codePointIndex++;
+        charIndex++;
       }
-      codePointIndex++;
-      charIndex++;
     }
   };
 

--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -1042,7 +1042,7 @@
         }
         entity = entities[entityIndex];
 
-        // There may be overalapping media entities with the same start index,
+        // There may be overlapping media entities with the same start index,
         // so don't move the codePointIndex or charIndex on this pass.
       } else {
         var c = text.charCodeAt(charIndex);


### PR DESCRIPTION
## Problem

For Tweets with multiple photos, the Twitter API returns duplicate entities (with the same start & end indices). The code for converting indices was skipping duplicate entities because it continued on starting from the end index of the first entity instead of remaining in place to convert the second.
## Solution

Break up the `convertUnicodeIndices` loop to not move the `charIndex` & `codePointIndex` when updating an entity's indices.
