### PR TITLE
Use RegEx literal instead of String literal

### DIFF
--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -240,7 +240,7 @@
 
   twttr.txt.regexen.validPortNumber = regexSupplant(/[0-9]+/);
 
-  twttr.txt.regexen.cyrillicLettersAndMarks = regexSupplant("\u0400-\u04FF");
+  twttr.txt.regexen.cyrillicLettersAndMarks = regexSupplant(/\u0400-\u04FF/);
   twttr.txt.regexen.validGeneralUrlPathChars = regexSupplant(/[a-z#{cyrillicLettersAndMarks}0-9!\*';:=\+,\.\$\/%#\[\]\-_~@\|&#{latinAccentChars}]/i);
   // Allow URL paths to contain up to two nested levels of balanced parens
   //  1. Used in Wikipedia URLs like /Primer_(film)


### PR DESCRIPTION
So here we go again, another escaped unicode partial inside a string literal. This gets exploded by the minifier, and then normalized by some browsers/proxies/etc..

This is the root cause of this bug: 
https://twitter.com/jamesreggio/status/705092597212192768

The solution is to put escape partials inside RegEx literals, or build them using other means. 
