### PR TITLE
cosmetic changes

### DIFF
--- a/java/docs/api/stylesheet.css
+++ b/java/docs/api/stylesheet.css
@@ -3,27 +3,26 @@
 /* Define colors, fonts and other style attributes here to override the defaults */
 
 /* Page background color */
-body { background-color: #FFFFFF; color:#000000 }
+body { background-color: #fff; color:#000; }
 
 /* Headings */
-h1 { font-size: 145% }
+h1 { font-size: 145%; }
 
 /* Table colors */
-.TableHeadingColor     { background: #CCCCFF; color:#000000 } /* Dark mauve */
-.TableSubHeadingColor  { background: #EEEEFF; color:#000000 } /* Light mauve */
-.TableRowColor         { background: #FFFFFF; color:#000000 } /* White */
+.TableHeadingColor     { background: #ccf; color: #000; } /* Dark mauve */
+.TableSubHeadingColor  { background: #eef; color: #000; } /* Light mauve */
+.TableRowColor         { background: #fff; color: #000; } /* White */
 
 /* Font used in left-hand frame lists */
-.FrameTitleFont   { font-size: 100%; font-family: Helvetica, Arial, sans-serif; color:#000000 }
-.FrameHeadingFont { font-size:  90%; font-family: Helvetica, Arial, sans-serif; color:#000000 }
-.FrameItemFont    { font-size:  90%; font-family: Helvetica, Arial, sans-serif; color:#000000 }
+.FrameTitleFont   { font-size: 100%; font-family: Helvetica, Arial, sans-serif; color: #000; }
+.FrameHeadingFont { font-size:  90%; font-family: Helvetica, Arial, sans-serif; color: #000; }
+.FrameItemFont    { font-size:  90%; font-family: Helvetica, Arial, sans-serif; color: #000; }
 
 /* Navigation bar fonts and colors */
-.NavBarCell1    { background-color:#EEEEFF; color:#000000} /* Light mauve */
-.NavBarCell1Rev { background-color:#00008B; color:#FFFFFF} /* Dark Blue */
-.NavBarFont1    { font-family: Arial, Helvetica, sans-serif; color:#000000;color:#000000;}
-.NavBarFont1Rev { font-family: Arial, Helvetica, sans-serif; color:#FFFFFF;color:#FFFFFF;}
+.NavBarCell1    { background-color: #eef; color: #000; } /* Light mauve */
+.NavBarCell1Rev { background-color: #00008b; color: #fff; } /* Dark Blue */
+.NavBarFont1    { font-family: Arial, Helvetica, sans-serif; color: #000; color: #000; }
+.NavBarFont1Rev { font-family: Arial, Helvetica, sans-serif; color: #fff; color: #fff; }
 
-.NavBarCell2    { font-family: Arial, Helvetica, sans-serif; background-color:#FFFFFF; color:#000000}
-.NavBarCell3    { font-family: Arial, Helvetica, sans-serif; background-color:#FFFFFF; color:#000000}
-
+.NavBarCell2    { font-family: Arial, Helvetica, sans-serif; background-color:#fff; color:#000; }
+.NavBarCell3    { font-family: Arial, Helvetica, sans-serif; background-color:#fff; color:#000; }


### PR DESCRIPTION
- use 3 digit shorthand notation for hex color code
- spacing consistency
- append last semi-colon on properties

Also is there a reason why 6 digit notation was used instead of the shorthand version? 
(just some really cosmetic changes so it doesn't have to be pushed)