### PR TITLE
Unit test to watch for unicode escapes in string literals

### DIFF
--- a/js/test/node_tests.js
+++ b/js/test/node_tests.js
@@ -11,4 +11,19 @@ assert.equal(typeof twitter.autoLink, 'function', 'twttr.txt is exported');
 assert.equal(typeof twttr, 'undefined', 'twttr is undefined after requiring twitter-text');
 assert.equal(typeof window, 'undefined', 'window is undefined after requiring twitter-text');
 
+var fs = require('fs');
+var path = require('path');
+fs.readFileSync(path.resolve(__dirname, '../twitter-text.js'), "utf8").split('\n').forEach(function(line, lineNumber) {
+  var isComment = false;
+  // This matches runs of 'foo' "bar" /meh/ or even // with escaping like "foo\"bar"
+  line.replace(/(["'\/])((?:(?!\1|\\).)*(?:\\.(?:(?!\1|\\).)*)*)\1/g, function(all, quote, content) {
+    if (isComment || quote == '/' && !content) {
+      isComment = true;
+    } else if (quote != '/') {
+      assert(!/(^|[^\\])\\u/.test(content), "Literal string contains potentially dangerous unicode escape on line " + (lineNumber + 1) +
+          " of twitter-text.js. It is safer to put these into a RegEx literal to avoid unicode normalization after minification.");
+    }
+  });
+});
+
 console.log("Node tests passed")


### PR DESCRIPTION
This is in response to @megaserg  's comment on https://github.com/twitter/twitter-text/pull/105