### PR TITLE
Nullability and generic annotations for Swift compatibility

### DIFF
--- a/objc/lib/TwitterText.h
+++ b/objc/lib/TwitterText.h
@@ -1,7 +1,7 @@
 //
 //  TwitterText.h
 //
-//  Copyright 2012-2014 Twitter, Inc.
+//  Copyright 2012-2016 Twitter, Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -13,15 +13,41 @@
 #import <Foundation/Foundation.h>
 #import "TwitterTextEntity.h"
 
+#if !__has_feature(nullability)
+#define nonnull
+#define nullable
+#define _Nullable
+#define _Nonnull
+#endif
+
+#ifndef NS_ASSUME_NONNULL_BEGIN
+#define NS_ASSUME_NONNULL_BEGIN
+#endif
+
+#ifndef NS_ASSUME_NONNULL_END
+#define NS_ASSUME_NONNULL_END
+#endif
+
+#if __has_feature(objc_generics)
+typedef NSArray<TwitterTextEntity *> TwitterTextEntityArray;
+typedef NSMutableArray<TwitterTextEntity *> TwitterTextMutableEntityArray;
+#else
+typedef NSArray TwitterTextEntityArray;
+typedef NSMutableArray TwitterTextMutableEntityArray;
+#endif
+
+
+NS_ASSUME_NONNULL_BEGIN
+
 @interface TwitterText : NSObject
 
-+ (NSArray *)entitiesInText:(NSString *)text;
-+ (NSArray *)URLsInText:(NSString *)text;
-+ (NSArray *)hashtagsInText:(NSString *)text checkingURLOverlap:(BOOL)checkingURLOverlap;
-+ (NSArray *)symbolsInText:(NSString *)text checkingURLOverlap:(BOOL)checkingURLOverlap;
-+ (NSArray *)mentionedScreenNamesInText:(NSString *)text;
-+ (NSArray *)mentionsOrListsInText:(NSString *)text;
-+ (TwitterTextEntity *)repliedScreenNameInText:(NSString *)text;
++ (TwitterTextEntityArray *)entitiesInText:(NSString *)text;
++ (TwitterTextEntityArray *)URLsInText:(NSString *)text;
++ (TwitterTextEntityArray *)hashtagsInText:(NSString *)text checkingURLOverlap:(BOOL)checkingURLOverlap;
++ (TwitterTextEntityArray *)symbolsInText:(NSString *)text checkingURLOverlap:(BOOL)checkingURLOverlap;
++ (TwitterTextEntityArray *)mentionedScreenNamesInText:(NSString *)text;
++ (TwitterTextEntityArray *)mentionsOrListsInText:(NSString *)text;
++ (nullable TwitterTextEntity *)repliedScreenNameInText:(NSString *)text;
 
 + (NSCharacterSet *)validHashtagBoundaryCharacterSet;
 
@@ -32,3 +58,5 @@
 + (NSInteger)remainingCharacterCount:(NSString *)text httpURLLength:(NSUInteger)httpURLLength httpsURLLength:(NSUInteger)httpsURLLength;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/objc/lib/TwitterText.m
+++ b/objc/lib/TwitterText.m
@@ -1,7 +1,7 @@
 //
 //  TwitterText.m
 //
-//  Copyright 2012-2014 Twitter, Inc.
+//  Copyright 2012-2016 Twitter, Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -292,25 +292,25 @@ static const NSUInteger HTTPSShortURLLength = 23;
 
 #pragma mark - Public Methods
 
-+ (NSArray *)entitiesInText:(NSString *)text
++ (TwitterTextEntityArray *)entitiesInText:(NSString *)text
 {
     if (!text.length) {
-        return [NSArray array];
+        return [TwitterTextEntityArray array];
     }
 
-    NSMutableArray *results = [NSMutableArray array];
+    TwitterTextMutableEntityArray *results = [TwitterTextMutableEntityArray array];
 
-    NSArray *urls = [self URLsInText:text];
+    TwitterTextEntityArray *urls = [self URLsInText:text];
     [results addObjectsFromArray:urls];
 
-    NSArray *hashtags = [self hashtagsInText:text withURLEntities:urls];
+    TwitterTextEntityArray *hashtags = [self hashtagsInText:text withURLEntities:urls];
     [results addObjectsFromArray:hashtags];
 
-    NSArray *symbols = [self symbolsInText:text withURLEntities:urls];
+    TwitterTextEntityArray *symbols = [self symbolsInText:text withURLEntities:urls];
     [results addObjectsFromArray:symbols];
 
-    NSArray *mentionsAndLists = [self mentionsOrListsInText:text];
-    NSMutableArray *addingItems = [NSMutableArray array];
+    TwitterTextEntityArray *mentionsAndLists = [self mentionsOrListsInText:text];
+    TwitterTextMutableEntityArray *addingItems = [TwitterTextMutableEntityArray array];
 
     for (TwitterTextEntity *entity in mentionsAndLists) {
         NSRange entityRange = entity.range;
@@ -332,13 +332,13 @@ static const NSUInteger HTTPSShortURLLength = 23;
     return results;
 }
 
-+ (NSArray *)URLsInText:(NSString *)text
++ (TwitterTextEntityArray *)URLsInText:(NSString *)text
 {
     if (!text.length) {
-        return [NSArray array];
+        return [TwitterTextEntityArray array];
     }
 
-    NSMutableArray *results = [NSMutableArray array];
+    TwitterTextMutableEntityArray *results = [TwitterTextMutableEntityArray array];
     NSUInteger len = text.length;
     NSUInteger position = 0;
     NSRange allRange = NSMakeRange(0, 0);
@@ -433,26 +433,26 @@ static const NSUInteger HTTPSShortURLLength = 23;
     return results;
 }
 
-+ (NSArray *)hashtagsInText:(NSString *)text checkingURLOverlap:(BOOL)checkingURLOverlap
++ (TwitterTextEntityArray *)hashtagsInText:(NSString *)text checkingURLOverlap:(BOOL)checkingURLOverlap
 {
     if (!text.length) {
-        return [NSArray array];
+        return [TwitterTextEntityArray array];
     }
 
-    NSArray *urls = nil;
+    TwitterTextEntityArray *urls = nil;
     if (checkingURLOverlap) {
         urls = [self URLsInText:text];
     }
     return [self hashtagsInText:text withURLEntities:urls];
 }
 
-+ (NSArray *)hashtagsInText:(NSString *)text withURLEntities:(NSArray *)urlEntities
++ (TwitterTextEntityArray *)hashtagsInText:(NSString *)text withURLEntities:(TwitterTextEntityArray *)urlEntities
 {
     if (!text.length) {
-        return [NSArray array];
+        return [TwitterTextEntityArray array];
     }
 
-    NSMutableArray *results = [NSMutableArray array];
+    TwitterTextMutableEntityArray *results = [TwitterTextMutableEntityArray array];
     NSUInteger len = text.length;
     NSUInteger position = 0;
 
@@ -494,26 +494,26 @@ static const NSUInteger HTTPSShortURLLength = 23;
     return results;
 }
 
-+ (NSArray *)symbolsInText:(NSString *)text checkingURLOverlap:(BOOL)checkingURLOverlap
++ (TwitterTextEntityArray *)symbolsInText:(NSString *)text checkingURLOverlap:(BOOL)checkingURLOverlap
 {
     if (!text.length) {
-        return [NSArray array];
+        return [TwitterTextEntityArray array];
     }
 
-    NSArray *urls = nil;
+    TwitterTextEntityArray *urls = nil;
     if (checkingURLOverlap) {
         urls = [self URLsInText:text];
     }
     return [self symbolsInText:text withURLEntities:urls];
 }
 
-+ (NSArray *)symbolsInText:(NSString *)text withURLEntities:(NSArray *)urlEntities
++ (TwitterTextEntityArray *)symbolsInText:(NSString *)text withURLEntities:(TwitterTextEntityArray *)urlEntities
 {
     if (!text.length) {
-        return [NSArray array];
+        return [TwitterTextEntityArray array];
     }
 
-    NSMutableArray *results = [NSMutableArray array];
+    TwitterTextMutableEntityArray *results = [TwitterTextMutableEntityArray array];
     NSUInteger len = text.length;
     NSUInteger position = 0;
 
@@ -545,14 +545,14 @@ static const NSUInteger HTTPSShortURLLength = 23;
     return results;
 }
 
-+ (NSArray *)mentionedScreenNamesInText:(NSString *)text
++ (TwitterTextEntityArray *)mentionedScreenNamesInText:(NSString *)text
 {
     if (!text.length) {
-        return [NSArray array];
+        return [TwitterTextEntityArray array];
     }
 
-    NSArray *mentionsOrLists = [self mentionsOrListsInText:text];
-    NSMutableArray *results = [NSMutableArray array];
+    TwitterTextEntityArray *mentionsOrLists = [self mentionsOrListsInText:text];
+    TwitterTextMutableEntityArray *results = [TwitterTextMutableEntityArray array];
 
     for (TwitterTextEntity *entity in mentionsOrLists) {
         if (entity.type == TwitterTextEntityScreenName) {
@@ -563,13 +563,13 @@ static const NSUInteger HTTPSShortURLLength = 23;
     return results;
 }
 
-+ (NSArray *)mentionsOrListsInText:(NSString *)text
++ (TwitterTextEntityArray *)mentionsOrListsInText:(NSString *)text
 {
     if (!text.length) {
-        return [NSArray array];
+        return [TwitterTextEntityArray array];
     }
 
-    NSMutableArray *results = [NSMutableArray array];
+    TwitterTextMutableEntityArray *results = [TwitterTextMutableEntityArray array];
     NSUInteger len = text.length;
     NSUInteger position = 0;
 
@@ -673,7 +673,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
 #endif
 
     NSUInteger urlLengthOffset = 0;
-    NSArray *urlEntities = [self URLsInText:text];
+    TwitterTextEntityArray *urlEntities = [self URLsInText:text];
     for (NSInteger i = (NSInteger)urlEntities.count - 1; i >= 0; i--) {
         TwitterTextEntity *entity = [urlEntities objectAtIndex:(NSUInteger)i];
         NSRange urlRange = entity.range;
@@ -723,7 +723,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
 
 #pragma mark - Private Methods
 
-+ (NSRegularExpression*)simplifiedValidURLRegexp
++ (NSRegularExpression *)simplifiedValidURLRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -733,7 +733,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)URLRegexpForValidation
++ (NSRegularExpression *)URLRegexpForValidation
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -743,7 +743,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)validASCIIDomainRegexp
++ (NSRegularExpression *)validASCIIDomainRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -753,7 +753,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)invalidShortDomainRegexp
++ (NSRegularExpression *)invalidShortDomainRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -763,7 +763,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)validSpecialShortDomainRegexp
++ (NSRegularExpression *)validSpecialShortDomainRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -773,7 +773,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)validTCOURLRegexp
++ (NSRegularExpression *)validTCOURLRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -783,7 +783,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)validHashtagRegexp
++ (NSRegularExpression *)validHashtagRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -793,7 +793,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)endHashtagRegexp
++ (NSRegularExpression *)endHashtagRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -803,7 +803,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)validSymbolRegexp
++ (NSRegularExpression *)validSymbolRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -813,7 +813,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)validMentionOrListRegexp
++ (NSRegularExpression *)validMentionOrListRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -823,7 +823,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)validReplyRegexp
++ (NSRegularExpression *)validReplyRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -833,7 +833,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSRegularExpression*)endMentionRegexp
++ (NSRegularExpression *)endMentionRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;
@@ -843,7 +843,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return regexp;
 }
 
-+ (NSCharacterSet*)invalidURLWithoutProtocolPrecedingCharSet
++ (NSCharacterSet *)invalidURLWithoutProtocolPrecedingCharSet
 {
     static NSCharacterSet *charSet;
     static dispatch_once_t onceToken;
@@ -856,7 +856,7 @@ static NSCharacterSet *validHashtagBoundaryCharacterSet()
     return charSet;
 }
 
-+ (NSRegularExpression*)validDomainSucceedingCharRegexp
++ (NSRegularExpression *)validDomainSucceedingCharRegexp
 {
     static NSRegularExpression *regexp;
     static dispatch_once_t onceToken;


### PR DESCRIPTION
This change adds nullability and array generic annotations to improve Swift compatibility. The `__has_feature` macro is used to ensure the compiler is new enough to support those annotations, and falls back if it doesn't. This technique is similar the one used in Fabric.
