### PR TITLE
fixes 'validateUrlDomain' regex

### DIFF
--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -309,7 +309,7 @@
   twttr.txt.regexen.validateUrlSubDomainSegment = /(?:[a-z0-9](?:[a-z0-9_\-]*[a-z0-9])?)/i;
   twttr.txt.regexen.validateUrlDomainSegment = /(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?)/i;
   twttr.txt.regexen.validateUrlDomainTld = /(?:[a-z](?:[a-z0-9\-]*[a-z0-9])?)/i;
-  twttr.txt.regexen.validateUrlDomain = regexSupplant(/(?:(?:#{validateUrlSubDomainSegment]}\.)*(?:#{validateUrlDomainSegment]}\.)#{validateUrlDomainTld})/i);
+  twttr.txt.regexen.validateUrlDomain = regexSupplant(/(?:(?:#{validateUrlSubDomainSegment}\.)*(?:#{validateUrlDomainSegment}\.)#{validateUrlDomainTld})/i);
 
   twttr.txt.regexen.validateUrlHost = regexSupplant('(?:' +
     '#{validateUrlIp}|' +


### PR DESCRIPTION
The RegExp for `twttr.txt.regexen.validateUrlUnicodeDomain` is broken as there are typos for the syntax of inner variables. 

This PR fixes the faulty regular expression, therefore also fixing the `twttr.txt.isValidUrl` function