### PR TITLE
Properly parse URLs with t.co referer

### DIFF
--- a/conformance/extract.yml
+++ b/conformance/extract.yml
@@ -580,6 +580,14 @@ tests:
         - url: "http://t.co/FNkPfmii"
           indices: [136, 156]
 
+    - description: "Properly extract URL that contains t.co in referer"
+      text: "http://www.foo.com?referer=https://t.co/abcde http://t.co/xyzzy"
+      expected:
+        - url: "http://www.foo.com?referer=https://t.co/abcde"
+          indices: [0, 45]
+        - url: "http://t.co/xyzzy"
+          indices: [46, 63]
+
     - description: "Extract correct indices for duplicate instances of the same URL"
       text: "http://t.co http://t.co"
       expected:

--- a/objc/lib/TwitterText.m
+++ b/objc/lib/TwitterText.m
@@ -269,7 +269,7 @@
     @"(?:[a-zA-Z0-9][a-zA-Z0-9\\-_" TWULatinAccents @"]*\\.)+" \
     @"(?:" TWUValidGTLD @"|" TWUValidCCTLD @"|" TWUValidPunycode @")(?=[^0-9a-z@]|$)"
 
-#define TWUValidTCOURL                  @"https?://t\\.co/[a-zA-Z0-9]+"
+#define TWUValidTCOURL                  @"^https?://t\\.co/[a-zA-Z0-9]+"
 #define TWUInvalidShortDomain           @"\\A" TWUValidDomainName TWUValidCCTLD @"\\z"
 #define TWUValidSpecialShortDomain      @"\\A" TWUValidDomainName TWUValidSpecialCCTLD @"\\z"
 

--- a/objc/test/json-conformance/extract.json
+++ b/objc/test/json-conformance/extract.json
@@ -1120,6 +1120,26 @@
         ]
       },
       {
+        "description": "Properly extract URL that contains t.co in referer",
+        "text": "http://www.foo.com?referer=https://t.co/abcde http://t.co/xyzzy",
+        "expected": [
+          {
+            "url": "http://www.foo.com?referer=https://t.co/abcde",
+            "indices": [
+              0,
+              45
+            ]
+          },
+          {
+            "url": "http://t.co/xyzzy",
+            "indices": [
+              46,
+              63
+            ]
+          }
+        ]
+      },
+      {
         "description": "Extract correct indices for duplicate instances of the same URL",
         "text": "http://t.co http://t.co",
         "expected": [


### PR DESCRIPTION
URLs that contain a t.co in the referer were not being properly parsed
in objc due to a missing anchor in the TWUValidTCOURL regex. The result
was that a URL of the form:

http://foo.com/xyz?referer=http://t.co/abcde

would be parsed as http://t.co/abcde

The java, js, and ruby implementations have the correct regex. Also
added a test case for this style of URL.