### PR TITLE
added special-use domain names

### DIFF
--- a/conformance/Rakefile
+++ b/conformance/Rakefile
@@ -25,6 +25,10 @@ namespace :tlds do
     end
 
     yml["generic"] << "onion"
+    yml["generic"] << "local"
+    yml["generic"] << "test"
+    yml["generic"] << "invalid"
+    yml["generic"] << "example"
 
     File.open(repo_path('tld_lib.yml'), 'w') do |file|
       file.write(yml.to_yaml)


### PR DESCRIPTION
There are some special-use domain names from IANA not only orion, and could you include these domain names into tld_lib.yml ?

Special-Use Domain Names:
https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml
