### PR TITLE
Allow a trailing single curly quote after a $cashtag

### DIFF
--- a/conformance/extract.yml
+++ b/conformance/extract.yml
@@ -849,6 +849,10 @@ tests:
       text: "#_ #1_2 #122 #〃"
       expected: []
 
+    - description: "Extract hashtag followed by curly quotes"
+      text: "#whatshappening’s trending."
+      expected: [whatshappening]
+
   hashtags_from_astral:
     - description: "Extract hashtag with letter from astral plane (U+20021)"
       text: "#\U00020021"
@@ -951,6 +955,10 @@ tests:
     - description: "Do not extract too long cashtags"
       text: "$CashtagMustBeLessThanSixCharacter"
       expected: []
+
+    - description: "Extract cashtag followed by curly quotes"
+      text: "$Stock’s trending."
+      expected: [Stock]
 
   cashtags_with_indices:
     - description: "Extract cashtags"

--- a/java/src/com/twitter/Regex.java
+++ b/java/src/com/twitter/Regex.java
@@ -263,7 +263,7 @@ public class Regex {
 
       VALID_URL = Pattern.compile(VALID_URL_PATTERN_STRING, Pattern.CASE_INSENSITIVE);
       VALID_TCO_URL = Pattern.compile("^https?:\\/\\/t\\.co\\/[a-z0-9]+", Pattern.CASE_INSENSITIVE);
-      VALID_CASHTAG = Pattern.compile("(^|" + UNICODE_SPACES + ")(" + DOLLAR_SIGN_CHAR + ")(" + CASHTAG + ")" + "(?=$|\\s|\\p{Punct})", Pattern.CASE_INSENSITIVE);
+      VALID_CASHTAG = Pattern.compile("(^|" + UNICODE_SPACES + ")(" + DOLLAR_SIGN_CHAR + ")(" + CASHTAG + ")" + "(?=$|\\s|\\p{Punct}|\\u2019)", Pattern.CASE_INSENSITIVE);
       VALID_DOMAIN = Pattern.compile(URL_VALID_DOMAIN, Pattern.CASE_INSENSITIVE);
     }
   }

--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -273,7 +273,7 @@
 
   // cashtag related regex
   twttr.txt.regexen.cashtag = /[a-z]{1,6}(?:[._][a-z]{1,2})?/i;
-  twttr.txt.regexen.validCashtag = regexSupplant('(^|#{spaces})(\\$)(#{cashtag})(?=$|\\s|[#{punct}])', 'gi');
+  twttr.txt.regexen.validCashtag = regexSupplant('(^|#{spaces})(\\$)(#{cashtag})(?=$|\\s|[#{punct}]|\u2019)', 'gi');
 
   // These URL validation pattern strings are based on the ABNF from RFC 3986
   twttr.txt.regexen.validateUrlUnreserved = /[a-z\u0400-\u04FF0-9\-._~]/i;

--- a/objc/lib/TwitterText.m
+++ b/objc/lib/TwitterText.m
@@ -82,7 +82,7 @@
 #define TWUValidSymbol \
     @"(?:^|[" TWUUnicodeSpaces @"])" \
     @"(\\$" TWUSymbol @")" \
-    @"(?=$|\\s|[" TWUPunctuationChars @"])"
+    @"(?=$|\\s|[" TWUPunctuationChars @"]|\\u2019)"
 
 //
 // Mention and list name

--- a/objc/tests/json-conformance/extract.json
+++ b/objc/tests/json-conformance/extract.json
@@ -1680,6 +1680,13 @@
         "expected": [
 
         ]
+      },
+      {
+        "description": "Extract hashtag followed by curly quotes",
+        "text": "#whatshappening’s trending.",
+        "expected": [
+          "whatshappening"
+        ]
       }
     ],
     "hashtags_from_astral": [
@@ -1900,6 +1907,13 @@
         "text": "$CashtagMustBeLessThanSixCharacter",
         "expected": [
 
+        ]
+      },
+      {
+        "description": "Extract cashtag followed by curly quotes",
+        "text": "$Stock’s trending.",
+        "expected": [
+          "Stock"
         ]
       }
     ],

--- a/rb/lib/twitter-text/regex.rb
+++ b/rb/lib/twitter-text/regex.rb
@@ -257,7 +257,7 @@ module Twitter
     }iox
 
     REGEXEN[:cashtag] = /[a-z]{1,6}(?:[._][a-z]{1,2})?/i
-    REGEXEN[:valid_cashtag] = /(^|#{REGEXEN[:spaces]})(\$)(#{REGEXEN[:cashtag]})(?=$|\s|[#{PUNCTUATION_CHARS}])/i
+    REGEXEN[:valid_cashtag] = /(^|#{REGEXEN[:spaces]})(\$)(#{REGEXEN[:cashtag]})(?=$|\s|[#{PUNCTUATION_CHARS}]|\u2019)/i
 
     # These URL validation pattern strings are based on the ABNF from RFC 3986
     REGEXEN[:validate_url_unreserved] = /[a-z\p{Cyrillic}0-9\-._~]/i


### PR DESCRIPTION
If someone pastes a tweet with a curly apostrophe after a valid cashtag, it should be recognised and linkified appropriately. 

This is working as expected for hashtags. I've added a test to make sure that remains the case. 