### PR TITLE
Ignore mentions in getTweetLength in JavaScript

### DIFF
--- a/js/test/tests.js
+++ b/js/test/tests.js
@@ -311,6 +311,7 @@ test("twttr.txt.extractUrls", function() {
 test("twttr.txt.getTweetLength", function() {
   equal(twttr.txt.getTweetLength(""), 0, "empty should be zero length.");
   equal(twttr.txt.getTweetLength("sample tweet"), 12, "small tweet should be counted correctly.");
+  equal(twttr.txt.getTweetLength("sample tweet @twitter"), 13, "should not count @mention.");
   equal(twttr.txt.getTweetLength("sample tweet with short url http://t.co/1"), 51, "Should count short URLs as 23");
   equal(twttr.txt.getTweetLength("sample tweet with short url http://t.co/this_is_really_really_really_really_really_long"), 94, "Should count long URLs as 23");
 });

--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -1162,8 +1162,14 @@
       };
     }
     var textLength = twttr.txt.getUnicodeTextLength(text),
-        urlsWithIndices = twttr.txt.extractUrlsWithIndices(text);
+        urlsWithIndices = twttr.txt.extractUrlsWithIndices(text),
+        mentionsWithIndices = twttr.txt.extractMentionsWithIndices(text);
     twttr.txt.modifyIndicesFromUTF16ToUnicode(text, urlsWithIndices);
+
+	for (var i = 0; i < mentionsWithIndices.length; i++) {
+      // Subtract the length of the @mention list
+      textLength += mentionsWithIndices[i].indices[0] - mentionsWithIndices[i].indices[1];
+    }
 
     for (var i = 0; i < urlsWithIndices.length; i++) {
       // Subtract the length of the original URL


### PR DESCRIPTION
Because of the recent update from twitter, now mentions are not counted
in tweet length. This PR makes the getTweetLength in JavaScript
file ignore the length of mentions.
Maybe other people can commit to this branch and modify the files in other languages.
[Look at this issue.](https://github.com/twitter/twitter-text/issues/182)