### PR TITLE
add support for en-dash u+2013 in URL paths

### DIFF
--- a/conformance/extract.yml
+++ b/conformance/extract.yml
@@ -332,6 +332,10 @@ tests:
       text: "Go to http://example.com/view/slug-url-?foo=bar"
       expected: ["http://example.com/view/slug-url-?foo=bar"]
 
+    - description: "Extract URLs with an en dash in the path"
+      text: "Go to https://en.m.wikipedia.org/wiki/Hatfield–McCoy_feud please"
+      expected: ["https://en.m.wikipedia.org/wiki/Hatfield–McCoy_feud"]
+
     - description: "Extract URLs beginning with a space"
       text: "@user Try http:// example.com/path"
       expected: ["example.com/path"]

--- a/java/src/com/twitter/Regex.java
+++ b/java/src/com/twitter/Regex.java
@@ -141,7 +141,7 @@ public class Regex {
   private static final String URL_VALID_PORT_NUMBER = "[0-9]++";
 
   private static final String URL_VALID_GENERAL_PATH_CHARS =
-    "[a-z0-9!\\*';:=\\+,.\\$/%#\\[\\]\\-_~\\|&@" + LATIN_ACCENTS_CHARS + CYRILLIC_CHARS + "]";
+    "[a-z0-9!\\*';:=\\+,.\\$/%#\\[\\]\\-\\u2013_~\\|&@" + LATIN_ACCENTS_CHARS + CYRILLIC_CHARS + "]";
   /** Allow URL paths to contain up to two nested levels of balanced parens
    *  1. Used in Wikipedia URLs like /Primer_(film)
    *  2. Used in IIS sessions like /S(dfd346)/

--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -219,7 +219,7 @@
   twttr.txt.regexen.validSpecialShortDomain = regexSupplant(/^#{validDomainName}#{validSpecialCCTLD}$/i);
   twttr.txt.regexen.validPortNumber = /[0-9]+/;
   twttr.txt.regexen.cyrillicLettersAndMarks = /\u0400-\u04FF/;
-  twttr.txt.regexen.validGeneralUrlPathChars = regexSupplant(/[a-z#{cyrillicLettersAndMarks}0-9!\*';:=\+,\.\$\/%#\[\]\-_~@\|&#{latinAccentChars}]/i);
+  twttr.txt.regexen.validGeneralUrlPathChars = regexSupplant(/[a-z#{cyrillicLettersAndMarks}0-9!\*';:=\+,\.\$\/%#\[\]\-\u2013_~@\|&#{latinAccentChars}]/i);
   // Allow URL paths to contain up to two nested levels of balanced parens
   //  1. Used in Wikipedia URLs like /Primer_(film)
   //  2. Used in IIS sessions like /S(dfd346)/

--- a/objc/lib/TwitterText.m
+++ b/objc/lib/TwitterText.m
@@ -275,7 +275,7 @@
 #define TWUValidSpecialShortDomain      @"\\A" TWUValidDomainName TWUValidSpecialCCTLD @"\\z"
 
 #define TWUValidPortNumber              @"[0-9]+"
-#define TWUValidGeneralURLPathChars     @"[a-zA-Z\\p{Cyrillic}0-9!\\*';:=+,.$/%#\\[\\]\\-_~&|@" TWULatinAccents @"]"
+#define TWUValidGeneralURLPathChars     @"[a-zA-Z\\p{Cyrillic}0-9!\\*';:=+,.$/%#\\[\\]\\-\\u2013_~&|@" TWULatinAccents @"]"
 
 #define TWUValidURLBalancedParens \
 @"\\(" \

--- a/rb/lib/twitter-text/regex.rb
+++ b/rb/lib/twitter-text/regex.rb
@@ -209,7 +209,7 @@ module Twitter
 
     REGEXEN[:valid_port_number] = /[0-9]+/
 
-    REGEXEN[:valid_general_url_path_chars] = /[a-z\p{Cyrillic}0-9!\*';:=\+\,\.\$\/%#\[\]\-_~&\|@#{LATIN_ACCENTS}]/io
+    REGEXEN[:valid_general_url_path_chars] = /[a-z\p{Cyrillic}0-9!\*';:=\+\,\.\$\/%#\[\]\-\u2013_~&\|@#{LATIN_ACCENTS}]/io
     # Allow URL paths to contain up to two nested levels of balanced parens
     #  1. Used in Wikipedia URLs like /Primer_(film)
     #  2. Used in IIS sessions like /S(dfd346)/


### PR DESCRIPTION
Wikipedia sometimes uses a unicode "en dash" (U+2013) in URL paths. This PR adds support to the URL extractor for this character. For example of a broken URL extraction, see https://twitter.com/raymastian/status/888524025592512512

closes #132 