### PR TITLE
Point twitter-text/js homepage URL to monorepo

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -6,11 +6,11 @@
   "files": [
     "twitter-text.js"
   ],
-  "homepage": "https://github.com/twitter/twitter-text-js",
+  "homepage": "https://github.com/twitter/twitter-text",
   "author": "Twitter Inc.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/twitter/twitter-text-js.git"
+    "url": "https://github.com/twitter/twitter-text.git"
   },
   "devDependencies": {
     "uglify-js": "~2.4.3",


### PR DESCRIPTION
The previous homepage URL redirects to https://github.com/twitter-archive/twitter-text-js , which just contains a deprecation notice pointing to this monorepo.

This patch updates the homepage URL in `package.json`, which should also fix the homepage URL on npm: https://www.npmjs.com/package/twitter-text