### PR TITLE
Update Cocoapods link in README

### DIFF
--- a/objc/README.rdoc
+++ b/objc/README.rdoc
@@ -1,4 +1,4 @@
-{rdoc-image:https://img.shields.io/cocoapods/v/twitter-text-objc.svg}[http://cocoapods.org/?q=twitter-text-objc]
+{rdoc-image:https://img.shields.io/cocoapods/v/twitter-text.svg}[http://cocoapods.org/?q=twitter-text]
 
 == twitter-text-objc
 


### PR DESCRIPTION
The Cocoapods link in the README was linking to the deprecated version. I had mistakenly used this version only to find out that it was not the correct one.