### PR TITLE
Updated Java implementation for 280 characters support

### DIFF
--- a/java/src/com/twitter/Validator.java
+++ b/java/src/com/twitter/Validator.java
@@ -6,16 +6,34 @@ import java.text.Normalizer;
  * A class for validating Tweet texts.
  */
 public class Validator {
+  @Deprecated
   public static final int MAX_TWEET_LENGTH = 140;
+  public static final int MAX_WEIGHTED_TWEET_LENGTH = 280;
 
   protected int shortUrlLength = 23;
   protected int shortUrlLengthHttps = 23;
 
+  protected int defaultWeight = 200;
+
   private Extractor extractor = new Extractor();
+  private WeightRange[] weightRanges = {
+          new WeightRange(0,4351,100),
+          new WeightRange(8192,8205,100),
+          new WeightRange(8208,8223,100),
+          new WeightRange(8242,8247,100),
+  };
 
   public int getTweetLength(String text) {
     text = Normalizer.normalize(text, Normalizer.Form.NFC);
-    int length = text.codePointCount(0, text.length());
+    int weightedLength = 0;
+
+    for(int charOffset = 0, textLength = text.length(); charOffset < textLength; ) {
+      final int codePoint = Character.codePointAt(text, charOffset);
+      weightedLength += weightForCodePoint(codePoint);
+      charOffset += Character.charCount(codePoint);
+    }
+
+    int length = weightedLength / 100;
 
     for (Extractor.Entity urlEntity : extractor.extractURLsWithIndices(text)) {
       length += urlEntity.start - urlEntity.end;
@@ -31,14 +49,14 @@ public class Validator {
     }
 
     for (char c : text.toCharArray()) {
-      if (c == '\uFFFE' || c == '\uuFEFF' ||   // BOM
+      if (c == '\uFFFE' || c == '\uFEFF' ||   // BOM
           c == '\uFFFF' ||                     // Special
           (c >= '\u202A' && c <= '\u202E')) {  // Direction change
         return false;
       }
     }
 
-    return getTweetLength(text) <= MAX_TWEET_LENGTH;
+    return getTweetLength(text) <= MAX_WEIGHTED_TWEET_LENGTH;
   }
 
   public int getShortUrlLength() {
@@ -55,5 +73,37 @@ public class Validator {
 
   public void setShortUrlLengthHttps(int shortUrlLengthHttps) {
     this.shortUrlLengthHttps = shortUrlLengthHttps;
+  }
+
+  public int getDefaultWeight() {
+    return defaultWeight;
+  }
+
+  public void setDefaultWeight(int defaultWeight) {
+    this.defaultWeight = defaultWeight;
+  }
+
+  private int weightForCodePoint(int codePoint) {
+    for (WeightRange range : weightRanges) {
+      if (range.contains(codePoint)) return range.weight;
+    }
+    return defaultWeight;
+  }
+
+  public static class WeightRange {
+
+    public final int start;
+    public final int end;
+    public final int weight;
+
+    public WeightRange(int start, int end, int weight) {
+      this.start = start;
+      this.end = end;
+      this.weight = weight;
+    }
+
+    public boolean contains(int codePoint) {
+      return codePoint >= start && codePoint <= end;
+    }
   }
 }

--- a/java/tests/com/twitter/ValidatorTest.java
+++ b/java/tests/com/twitter/ValidatorTest.java
@@ -26,7 +26,7 @@ public class ValidatorTest extends TestCase {
   public void testAccentCharacters() {
     String c = "\u0065\u0301";
     StringBuilder builder = new StringBuilder();
-    for (int i = 0; i < 139; i++) {
+    for (int i = 0; i < 279; i++) {
       builder.append(c);
     }
     assertTrue(validator.isValidTweet(builder.toString()));


### PR DESCRIPTION
This PR adds 280 characters support for issue #196, according to Twitter's [official documentation](https://developer.twitter.com/en/docs/developer-utilities/twitter-text.html)