### PR TITLE
Fix linkToTextWithSymbol.js from accessing global variable

### DIFF
--- a/js/src/linkToTextWithSymbol.js
+++ b/js/src/linkToTextWithSymbol.js
@@ -1,3 +1,4 @@
+import atSigns from './regexp/atSigns';
 import htmlEscape from './htmlEscape';
 import linkToText from './linkToText';
 
@@ -6,7 +7,7 @@ export default function (entity, symbol, text, attributes, options) {
   text = htmlEscape(text);
   const taggedText = options.textWithSymbolTag ? `<${options.textWithSymbolTag}>${text}</${options.textWithSymbolTag}>` : text;
 
-  if (options.usernameIncludeSymbol || !symbol.match(twttr.txt.regexen.atSigns)) {
+  if (options.usernameIncludeSymbol || !symbol.match(atSigns)) {
     return linkToText(entity, taggedSymbol + taggedText, attributes, options);
   } else {
     return taggedSymbol + linkToText(entity, taggedText, attributes, options);


### PR DESCRIPTION
Using global variable `twttr.txt` directly throws error on node.js environment

https://github.com/twitter/twitter-text/blob/58188ccf8d083722d08d9b2d17686eb82d74ebdf/js/src/linkToTextWithSymbol.js#L9

```js
import twitter from './build/twitter-text';

const text = '@twitterdev';

const linkified = twitter.autoLink(text); // ReferenceError: twttr is not defined

console.log(linkified);
```