### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twitter-text",
   "description": "official twitter text linkification",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "build/twitter-text.js",
   "files": [
     "build/twitter-text.js"


### PR DESCRIPTION
Contains important fix in [this PR](https://github.com/twitter/twitter-text/pull/209) to remove last reference twttr.txt global namespace that was part of legacy code in 1.0 