### PR TITLE
Fix dangling symlink (Issue #211)

### DIFF
--- a/rb/Rakefile
+++ b/rb/Rakefile
@@ -8,10 +8,12 @@ task :default => ['prebuild', 'spec', 'test:conformance']
 task :test => :spec
 
 directory "config"
+directory "lib/assets"
 
 desc "Prebuild task setup"
-task :prebuild => ["config"] do
+task :prebuild => ["config", "lib/assets"] do
   FileUtils.cp_r '../config/.', 'config', :verbose => true
+  FileUtils.cp_r '../conformance/tld_lib.yml', 'lib/assets', :verbose => true
 end
 
 require 'rubygems'
@@ -46,5 +48,5 @@ end
 
 desc "Clean build"
 task :clean do
-  rm_rf ["config", "pkg", "Gemfile.lock"]
+  rm_rf ["config", "pkg", "lib/assets", "Gemfile.lock"]
 end

--- a/rb/lib/assets/tld_lib.yml
+++ b/rb/lib/assets/tld_lib.yml
@@ -1,1 +1,0 @@
-../../../conformance/tld_lib.yml

--- a/rb/twitter-text.gemspec
+++ b/rb/twitter-text.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "twitter-text"
-  s.version = "2.0.1"
+  s.version = "2.0.2"
   s.authors = ["David LaMacchia", "Sudheer Guntupalli", "Kaushik Lakshmikanth", "Jose Antonio Marquez Russo", "Lee Adams",
                "Yoshimasa Niwa"]
   s.email = ["opensource@twitter.com"]


### PR DESCRIPTION
This is only an issue when packaging the ruby gem. The tld_lib.yml file
was a symlink which was missing from the gem.