### PR TITLE
Rename Configuration to avoid conflicts with twitter gem

### DIFF
--- a/rb/lib/twitter-text/configuration.rb
+++ b/rb/lib/twitter-text/configuration.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
 module Twitter
-  class Configuration
+  class TextConfiguration
     require 'json'
 
     PARSER_VERSION_CLASSIC = "v1"
@@ -35,7 +35,7 @@ module Twitter
 
     def self.configuration_from_file(filename)
       config = parse_file(filename)
-      config ? Twitter::Configuration.new(config) : nil
+      config ? Twitter::TextConfiguration.new(config) : nil
     end
 
     def initialize(config = {})
@@ -47,7 +47,7 @@ module Twitter
       @ranges = config[:ranges].map { |range| Twitter::WeightedRange.new(range) } if config.key?(:ranges) && config[:ranges].is_a?(Array)
     end
 
-    self.default_configuration = Twitter::Configuration.configuration_from_file(Twitter::Configuration::CONFIG_V2)
+    self.default_configuration = Twitter::TextConfiguration.configuration_from_file(Twitter::TextConfiguration::CONFIG_V2)
   end
 end
 

--- a/rb/lib/twitter-text/validation.rb
+++ b/rb/lib/twitter-text/validation.rb
@@ -31,7 +31,7 @@ module Twitter
     # Parse input text and return hash with descriptive parameters populated.
     def parse_tweet(text, options = {})
       options = DEFAULT_TCO_URL_LENGTHS.merge(options)
-      config = options[:config] || Twitter::Configuration.default_configuration
+      config = options[:config] || Twitter::TextConfiguration.default_configuration
       normalized_text = text.to_nfc
       normalized_text_length = normalized_text.char_length
       unless (normalized_text_length > 0)

--- a/rb/spec/configuration_spec.rb
+++ b/rb/spec/configuration_spec.rb
@@ -1,34 +1,34 @@
 # encoding: utf-8
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe Twitter::Configuration do
+describe Twitter::TextConfiguration do
   context "configuration" do
     context "with invalid data" do
       it "should raise an exception" do
-        invalid_hash = Twitter::Configuration.parse_string("{\"version\":2,\"maxWeightedTweetLength\":280,\"scale\":100,\"defaultWeight\":200,\"transformedURLLength\":23,\"ranges\":[{\"start\":0,\"end\":true,\"weight\":false},{\"start\":8192,\"end\":8205,\"weight\":100},{\"start\":8208,\"end\":8223,\"weight\":100},{\"start\":8242,\"end\":8247,\"weight\":100}]}")
-        expect { Twitter::Configuration.new(invalid_hash) }.to raise_error(ArgumentError)
+        invalid_hash = Twitter::TextConfiguration.parse_string("{\"version\":2,\"maxWeightedTweetLength\":280,\"scale\":100,\"defaultWeight\":200,\"transformedURLLength\":23,\"ranges\":[{\"start\":0,\"end\":true,\"weight\":false},{\"start\":8192,\"end\":8205,\"weight\":100},{\"start\":8208,\"end\":8223,\"weight\":100},{\"start\":8242,\"end\":8247,\"weight\":100}]}")
+        expect { Twitter::TextConfiguration.new(invalid_hash) }.to raise_error(ArgumentError)
       end
     end
 
     context "with defaults" do
       before do
-        Twitter::Configuration.default_configuration = Twitter::Configuration.configuration_from_file(Twitter::Configuration::CONFIG_V2)
+        Twitter::TextConfiguration.default_configuration = Twitter::TextConfiguration.configuration_from_file(Twitter::TextConfiguration::CONFIG_V2)
       end
 
       it "should define version constants" do
-        expect(Twitter::Configuration.const_defined?(:CONFIG_V1)).to be true
-        expect(Twitter::Configuration.const_defined?(:CONFIG_V2)).to be true
+        expect(Twitter::TextConfiguration.const_defined?(:CONFIG_V1)).to be true
+        expect(Twitter::TextConfiguration.const_defined?(:CONFIG_V2)).to be true
       end
 
       it "should define a default configuration" do
-        expect(Twitter::Configuration.default_configuration).to_not be_nil
-        expect(Twitter::Configuration.default_configuration.version).to eq(2)
+        expect(Twitter::TextConfiguration.default_configuration).to_not be_nil
+        expect(Twitter::TextConfiguration.default_configuration.version).to eq(2)
       end
     end
 
     context "with v1 configuration" do
       before do
-        @config = Twitter::Configuration.configuration_from_file(Twitter::Configuration::CONFIG_V1)
+        @config = Twitter::TextConfiguration.configuration_from_file(Twitter::TextConfiguration::CONFIG_V1)
       end
 
       it "should have a version" do
@@ -54,7 +54,7 @@ describe Twitter::Configuration do
 
     context "with v2 configuration" do
       before do
-        @config = Twitter::Configuration.configuration_from_file(Twitter::Configuration::CONFIG_V2)
+        @config = Twitter::TextConfiguration.configuration_from_file(Twitter::TextConfiguration::CONFIG_V2)
       end
 
       it "should have a version" do


### PR DESCRIPTION
The Configuration class that was added conflicts with the twitter gem. This PR renames that class to avoid the naming conflict as described in #221 