### PR TITLE
[#211] Update top-level namespace to Twitter::TwitterText::

### DIFF
--- a/rb/CHANGELOG.md
+++ b/rb/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [2.1] - 2017-12-20
+### Added
+- This CHANGELOG.md file
+
+### Changed
+- Top-level namespace changed from `Twitter` to `Twitter::TwitterText`. This
+  resolves a namespace collision with the popular
+  [twitter gem](https://github.com/sferik/twitter). This is considered
+  a breaking change, so the version has been bumped to 2.1. This fixes
+  issue [#221](https://github.com/twitter/twitter-text/issues/221),
+  "NoMethodError Exception: undefined method `[]' for nil:NilClasswhen
+  using gem in rails app"
+
+## [2.0.2] - 2017-12-18
+### Changed
+- Resolved issue
+  [#211](https://github.com/twitter/twitter-text/issues/211), "gem
+  breaks, asset file is a dangling symlink"
+- config files, tld_lib.yml files now copied into the right place
+- Rakefile now included `prebuild`, `clean` tasks

--- a/rb/README.md
+++ b/rb/README.md
@@ -50,7 +50,7 @@ def parse_tweet(text, options = {}) { ... }
 
 This method takes a string as input and returns a results object that
 contains information about the
-string. `Twitter::Validation::ParseResults` object includes:
+string. `Twitter::TwitterText::Validation::ParseResults` object includes:
 
 * `:weighted_length`: the overall length of the tweet with code points
 weighted per the ranges defined in the configuration file.
@@ -78,7 +78,7 @@ payload see [Tweet updates](https://developer.twitter.com/en/docs/tweets/tweet-u
 # Extraction
 ```ruby
 class MyClass
-  include Twitter::Extractor
+  include Twitter::TwitterText::Extractor
   usernames = extract_mentioned_screen_names("Mentioning @twitter and @jack")
   # usernames = ["twitter", "jack"]
 end
@@ -88,7 +88,7 @@ end
 
 ```ruby
 class MyClass
-  include Twitter::Extractor
+  include Twitter::TwitterText::Extractor
   extract_reply_screen_name("@twitter are you hiring?").do |username|
     # username = "twitter"
   end
@@ -101,7 +101,7 @@ end
 
 ```ruby
 class MyClass
-  include Twitter::Autolink
+  include Twitter::TwitterText::Autolink
 
   html = auto_link("link @user, please #request")
 end
@@ -110,7 +110,7 @@ end
 ### For Ruby on Rails you want to add this to app/helpers/application_helper.rb
 ```ruby
 module ApplicationHelper
-  include Twitter::Autolink
+  include Twitter::TwitterText::Autolink
 end
 ```
 

--- a/rb/lib/twitter-text/autolink.rb
+++ b/rb/lib/twitter-text/autolink.rb
@@ -4,445 +4,446 @@ require 'set'
 require 'twitter-text/hash_helper'
 
 module Twitter
-  # A module for including Tweet auto-linking in a class. The primary use of this is for helpers/views so they can auto-link
-  # usernames, lists, hashtags and URLs.
-  module Autolink extend self
-    # Default CSS class for auto-linked lists
-    DEFAULT_LIST_CLASS = "tweet-url list-slug".freeze
-    # Default CSS class for auto-linked usernames
-    DEFAULT_USERNAME_CLASS = "tweet-url username".freeze
-    # Default CSS class for auto-linked hashtags
-    DEFAULT_HASHTAG_CLASS = "tweet-url hashtag".freeze
-    # Default CSS class for auto-linked cashtags
-    DEFAULT_CASHTAG_CLASS = "tweet-url cashtag".freeze
+  module TwitterText
+    # A module for including Tweet auto-linking in a class. The primary use of this is for helpers/views so they can auto-link
+    # usernames, lists, hashtags and URLs.
+    module Autolink extend self
+      # Default CSS class for auto-linked lists
+      DEFAULT_LIST_CLASS = "tweet-url list-slug".freeze
+      # Default CSS class for auto-linked usernames
+      DEFAULT_USERNAME_CLASS = "tweet-url username".freeze
+      # Default CSS class for auto-linked hashtags
+      DEFAULT_HASHTAG_CLASS = "tweet-url hashtag".freeze
+      # Default CSS class for auto-linked cashtags
+      DEFAULT_CASHTAG_CLASS = "tweet-url cashtag".freeze
 
-    # Default URL base for auto-linked usernames
-    DEFAULT_USERNAME_URL_BASE = "https://twitter.com/".freeze
-    # Default URL base for auto-linked lists
-    DEFAULT_LIST_URL_BASE = "https://twitter.com/".freeze
-    # Default URL base for auto-linked hashtags
-    DEFAULT_HASHTAG_URL_BASE = "https://twitter.com/search?q=%23".freeze
-    # Default URL base for auto-linked cashtags
-    DEFAULT_CASHTAG_URL_BASE = "https://twitter.com/search?q=%24".freeze
+      # Default URL base for auto-linked usernames
+      DEFAULT_USERNAME_URL_BASE = "https://twitter.com/".freeze
+      # Default URL base for auto-linked lists
+      DEFAULT_LIST_URL_BASE = "https://twitter.com/".freeze
+      # Default URL base for auto-linked hashtags
+      DEFAULT_HASHTAG_URL_BASE = "https://twitter.com/search?q=%23".freeze
+      # Default URL base for auto-linked cashtags
+      DEFAULT_CASHTAG_URL_BASE = "https://twitter.com/search?q=%24".freeze
 
-    # Default attributes for invisible span tag
-    DEFAULT_INVISIBLE_TAG_ATTRS = "style='position:absolute;left:-9999px;'".freeze
+      # Default attributes for invisible span tag
+      DEFAULT_INVISIBLE_TAG_ATTRS = "style='position:absolute;left:-9999px;'".freeze
 
-    DEFAULT_OPTIONS = {
-      :list_class     => DEFAULT_LIST_CLASS,
-      :username_class => DEFAULT_USERNAME_CLASS,
-      :hashtag_class  => DEFAULT_HASHTAG_CLASS,
-      :cashtag_class  => DEFAULT_CASHTAG_CLASS,
+      DEFAULT_OPTIONS = {
+        :list_class     => DEFAULT_LIST_CLASS,
+        :username_class => DEFAULT_USERNAME_CLASS,
+        :hashtag_class  => DEFAULT_HASHTAG_CLASS,
+        :cashtag_class  => DEFAULT_CASHTAG_CLASS,
 
-      :username_url_base => DEFAULT_USERNAME_URL_BASE,
-      :list_url_base     => DEFAULT_LIST_URL_BASE,
-      :hashtag_url_base  => DEFAULT_HASHTAG_URL_BASE,
-      :cashtag_url_base  => DEFAULT_CASHTAG_URL_BASE,
+        :username_url_base => DEFAULT_USERNAME_URL_BASE,
+        :list_url_base     => DEFAULT_LIST_URL_BASE,
+        :hashtag_url_base  => DEFAULT_HASHTAG_URL_BASE,
+        :cashtag_url_base  => DEFAULT_CASHTAG_URL_BASE,
 
-      :invisible_tag_attrs => DEFAULT_INVISIBLE_TAG_ATTRS
-    }.freeze
+        :invisible_tag_attrs => DEFAULT_INVISIBLE_TAG_ATTRS
+      }.freeze
 
-    def auto_link_with_json(text, json, options = {})
-      # concatenate entities
-      entities = json.values().flatten()
+      def auto_link_with_json(text, json, options = {})
+        # concatenate entities
+        entities = json.values().flatten()
 
-      # map JSON entity to twitter-text entity
-      # be careful not to alter arguments received
-      entities.map! do |entity|
-        entity = HashHelper.symbolize_keys(entity)
-        # hashtag
-        entity[:hashtag] = entity[:text] if entity[:text]
-        entity
-      end
-
-      auto_link_entities(text, entities, options)
-    end
-
-    def auto_link_entities(text, entities, options = {}, &block)
-      return text if entities.empty?
-
-      # NOTE deprecate these attributes not options keys in options hash, then use html_attrs
-      options = DEFAULT_OPTIONS.merge(options)
-      options[:html_attrs] = extract_html_attrs_from_options!(options)
-      options[:html_attrs][:rel] ||= "nofollow" unless options[:suppress_no_follow]
-      options[:html_attrs][:target] = "_blank" if options[:target_blank] == true
-
-      Twitter::Rewriter.rewrite_entities(text.dup, entities) do |entity, chars|
-        if entity[:url]
-          link_to_url(entity, chars, options, &block)
-        elsif entity[:hashtag]
-          link_to_hashtag(entity, chars, options, &block)
-        elsif entity[:screen_name]
-          link_to_screen_name(entity, chars, options, &block)
-        elsif entity[:cashtag]
-          link_to_cashtag(entity, chars, options, &block)
-        end
-      end
-    end
-
-    # Add <tt><a></a></tt> tags around the usernames, lists, hashtags and URLs in the provided <tt>text</tt>.
-    # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash:
-    # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
-    # and place in the <tt><a></tt> tag.
-    #
-    # <tt>:url_class</tt>::      class to add to url <tt><a></tt> tags
-    # <tt>:list_class</tt>::     class to add to list <tt><a></tt> tags
-    # <tt>:username_class</tt>:: class to add to username <tt><a></tt> tags
-    # <tt>:hashtag_class</tt>::  class to add to hashtag <tt><a></tt> tags
-    # <tt>:cashtag_class</tt>::  class to add to cashtag <tt><a></tt> tags
-    # <tt>:username_url_base</tt>::  the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
-    # <tt>:list_url_base</tt>::      the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
-    # <tt>:hashtag_url_base</tt>::   the value for <tt>href</tt> attribute on hashtag links. The <tt>#hashtag</tt> (minus the <tt>#</tt>) will be appended at the end of this.
-    # <tt>:cashtag_url_base</tt>::   the value for <tt>href</tt> attribute on cashtag links. The <tt>$cashtag</tt> (minus the <tt>$</tt>) will be appended at the end of this.
-    # <tt>:invisible_tag_attrs</tt>::   HTML attribute to add to invisible span tags
-    # <tt>:username_include_symbol</tt>:: place the <tt>@</tt> symbol within username and list links
-    # <tt>:suppress_lists</tt>::          disable auto-linking to lists
-    # <tt>:suppress_no_follow</tt>::      do not add <tt>rel="nofollow"</tt> to auto-linked items
-    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
-    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
-    # <tt>:url_target</tt>::     the value for <tt>target</tt> attribute on URL links.
-    # <tt>:target_blank</tt>:: adds <tt>target="_blank"</tt> to all auto_linked items username / hashtag / cashtag links / urls
-    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
-    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
-    def auto_link(text, options = {}, &block)
-      auto_link_entities(text, Extractor.extract_entities_with_indices(text, :extract_url_without_protocol => false), options, &block)
-    end
-
-    # Add <tt><a></a></tt> tags around the usernames and lists in the provided <tt>text</tt>. The
-    # <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
-    # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
-    # and place in the <tt><a></tt> tag.
-    #
-    # <tt>:list_class</tt>::     class to add to list <tt><a></tt> tags
-    # <tt>:username_class</tt>:: class to add to username <tt><a></tt> tags
-    # <tt>:username_url_base</tt>:: the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
-    # <tt>:list_url_base</tt>::     the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
-    # <tt>:username_include_symbol</tt>:: place the <tt>@</tt> symbol within username and list links
-    # <tt>:suppress_lists</tt>::          disable auto-linking to lists
-    # <tt>:suppress_no_follow</tt>::      do not add <tt>rel="nofollow"</tt> to auto-linked items
-    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
-    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
-    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
-    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
-    def auto_link_usernames_or_lists(text, options = {}, &block) # :yields: list_or_username
-      auto_link_entities(text, Extractor.extract_mentions_or_lists_with_indices(text), options, &block)
-    end
-
-    # Add <tt><a></a></tt> tags around the hashtags in the provided <tt>text</tt>.
-    # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
-    # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
-    # and place in the <tt><a></tt> tag.
-    #
-    # <tt>:hashtag_class</tt>:: class to add to hashtag <tt><a></tt> tags
-    # <tt>:hashtag_url_base</tt>:: the value for <tt>href</tt> attribute. The hashtag text (minus the <tt>#</tt>) will be appended at the end of this.
-    # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
-    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
-    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
-    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
-    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
-    def auto_link_hashtags(text, options = {}, &block)  # :yields: hashtag_text
-      auto_link_entities(text, Extractor.extract_hashtags_with_indices(text), options, &block)
-    end
-
-    # Add <tt><a></a></tt> tags around the cashtags in the provided <tt>text</tt>.
-    # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
-    # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
-    # and place in the <tt><a></tt> tag.
-    #
-    # <tt>:cashtag_class</tt>:: class to add to cashtag <tt><a></tt> tags
-    # <tt>:cashtag_url_base</tt>:: the value for <tt>href</tt> attribute. The cashtag text (minus the <tt>$</tt>) will be appended at the end of this.
-    # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
-    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
-    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
-    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
-    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
-    def auto_link_cashtags(text, options = {}, &block)  # :yields: cashtag_text
-      auto_link_entities(text, Extractor.extract_cashtags_with_indices(text), options, &block)
-    end
-
-    # Add <tt><a></a></tt> tags around the URLs in the provided <tt>text</tt>.
-    # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
-    # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
-    # and place in the <tt><a></tt> tag.
-    #
-    # <tt>:url_class</tt>::     class to add to url <tt><a></tt> tags
-    # <tt>:invisible_tag_attrs</tt>::   HTML attribute to add to invisible span tags
-    # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
-    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
-    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
-    # <tt>:url_target</tt>::     the value for <tt>target</tt> attribute on URL links.
-    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
-    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
-    def auto_link_urls(text, options = {}, &block)
-      auto_link_entities(text, Extractor.extract_urls_with_indices(text, :extract_url_without_protocol => false), options, &block)
-    end
-
-    # These methods are deprecated, will be removed in future.
-    extend Deprecation
-
-    # <b>Deprecated</b>: Please use auto_link_urls instead.
-    # Add <tt><a></a></tt> tags around the URLs in the provided <tt>text</tt>.
-    # Any elements in the <tt>href_options</tt> hash will be converted to HTML attributes
-    # and place in the <tt><a></tt> tag.
-    # Unless <tt>href_options</tt> contains <tt>:suppress_no_follow</tt>
-    # the <tt>rel="nofollow"</tt> attribute will be added.
-    alias :auto_link_urls_custom :auto_link_urls
-    deprecate :auto_link_urls_custom, :auto_link_urls
-
-    private
-
-    HTML_ENTITIES = {
-      '&' => '&amp;',
-      '>' => '&gt;',
-      '<' => '&lt;',
-      '"' => '&quot;',
-      "'" => '&#39;'
-    }
-
-    def html_escape(text)
-      text && text.to_s.gsub(/[&"'><]/) do |character|
-        HTML_ENTITIES[character]
-      end
-    end
-
-    # NOTE We will make this private in future.
-    public :html_escape
-
-    # Options which should not be passed as HTML attributes
-    OPTIONS_NOT_ATTRIBUTES = Set.new([
-      :url_class, :list_class, :username_class, :hashtag_class, :cashtag_class,
-      :username_url_base, :list_url_base, :hashtag_url_base, :cashtag_url_base,
-      :username_url_block, :list_url_block, :hashtag_url_block, :cashtag_url_block, :link_url_block,
-      :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities,
-      :invisible_tag_attrs, :symbol_tag, :text_with_symbol_tag, :url_target, :target_blank,
-      :link_attribute_block, :link_text_block
-    ]).freeze
-
-    def extract_html_attrs_from_options!(options)
-      html_attrs = {}
-      options.reject! do |key, value|
-        unless OPTIONS_NOT_ATTRIBUTES.include?(key)
-          html_attrs[key] = value
-          true
-        end
-      end
-      html_attrs
-    end
-
-    def url_entities_hash(url_entities)
-      (url_entities || {}).inject({}) do |entities, entity|
+        # map JSON entity to twitter-text entity
         # be careful not to alter arguments received
-        _entity = HashHelper.symbolize_keys(entity)
-        entities[_entity[:url]] = _entity
-        entities
-      end
-    end
-
-    def link_to_url(entity, chars, options = {})
-      url = entity[:url]
-
-      href = if options[:link_url_block]
-        options[:link_url_block].call(url)
-      else
-        url
-      end
-
-      # NOTE auto link to urls do not use any default values and options
-      # like url_class but use suppress_no_follow.
-      html_attrs = options[:html_attrs].dup
-      html_attrs[:class] = options[:url_class] if options.key?(:url_class)
-
-      # add target attribute only if :url_target is specified
-      html_attrs[:target] = options[:url_target] if options.key?(:url_target)
-
-      url_entities = url_entities_hash(options[:url_entities])
-
-      # use entity from urlEntities if available
-      url_entity = url_entities[url] || entity
-      link_text = if url_entity[:display_url]
-        html_attrs[:title] ||= url_entity[:expanded_url]
-        link_url_with_entity(url_entity, options)
-      else
-        html_escape(url)
-      end
-
-      link_to_text(entity, link_text, href, html_attrs, options)
-    end
-
-    def link_url_with_entity(entity, options)
-      display_url = entity[:display_url]
-      expanded_url = entity[:expanded_url]
-      invisible_tag_attrs = options[:invisible_tag_attrs] || DEFAULT_INVISIBLE_TAG_ATTRS
-
-      # Goal: If a user copies and pastes a tweet containing t.co'ed link, the resulting paste
-      # should contain the full original URL (expanded_url), not the display URL.
-      #
-      # Method: Whenever possible, we actually emit HTML that contains expanded_url, and use
-      # font-size:0 to hide those parts that should not be displayed (because they are not part of display_url).
-      # Elements with font-size:0 get copied even though they are not visible.
-      # Note that display:none doesn't work here. Elements with display:none don't get copied.
-      #
-      # Additionally, we want to *display* ellipses, but we don't want them copied.  To make this happen we
-      # wrap the ellipses in a tco-ellipsis class and provide an onCopy handler that sets display:none on
-      # everything with the tco-ellipsis class.
-      #
-      # Exception: pic.twitter.com images, for which expandedUrl = "https://twitter.com/username/status/1234/photo/1
-      # For those URLs, display_url is not a substring of expanded_url, so we don't do anything special to render the elided parts.
-      # For a pic.twitter.com URL, the only elided part will be the "https://", so this is fine.
-      display_url_sans_ellipses = display_url.gsub("…", "")
-
-      if expanded_url.include?(display_url_sans_ellipses)
-        before_display_url, after_display_url = expanded_url.split(display_url_sans_ellipses, 2)
-        preceding_ellipsis = /\A…/.match(display_url).to_s
-        following_ellipsis = /…\z/.match(display_url).to_s
-
-        # As an example: The user tweets "hi http://longdomainname.com/foo"
-        # This gets shortened to "hi http://t.co/xyzabc", with display_url = "…nname.com/foo"
-        # This will get rendered as:
-        # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
-        #   …
-        #   <!-- There's a chance the onCopy event handler might not fire. In case that happens,
-        #        we include an &nbsp; here so that the … doesn't bump up against the URL and ruin it.
-        #        The &nbsp; is inside the tco-ellipsis span so that when the onCopy handler *does*
-        #        fire, it doesn't get copied.  Otherwise the copied text would have two spaces in a row,
-        #        e.g. "hi  http://longdomainname.com/foo".
-        #   <span style='font-size:0'>&nbsp;</span>
-        # </span>
-        # <span style='font-size:0'>  <!-- This stuff should get copied but not displayed -->
-        #   http://longdomai
-        # </span>
-        # <span class='js-display-url'> <!-- This stuff should get displayed *and* copied -->
-        #   nname.com/foo
-        # </span>
-        # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
-        #   <span style='font-size:0'>&nbsp;</span>
-        #   …
-        # </span>
-        %(<span class="tco-ellipsis">#{preceding_ellipsis}<span #{invisible_tag_attrs}>&nbsp;</span></span>) <<
-        %(<span #{invisible_tag_attrs}>#{html_escape(before_display_url)}</span>) <<
-        %(<span class="js-display-url">#{html_escape(display_url_sans_ellipses)}</span>) <<
-        %(<span #{invisible_tag_attrs}>#{html_escape(after_display_url)}</span>) <<
-        %(<span class="tco-ellipsis"><span #{invisible_tag_attrs}>&nbsp;</span>#{following_ellipsis}</span>)
-      else
-        html_escape(display_url)
-      end
-    end
-
-    def link_to_hashtag(entity, chars, options = {})
-      hash = chars[entity[:indices].first]
-      hashtag = entity[:hashtag]
-      hashtag = yield(hashtag) if block_given?
-      hashtag_class = options[:hashtag_class].to_s
-
-      if hashtag.match Twitter::Regex::REGEXEN[:rtl_chars]
-        hashtag_class += ' rtl'
-      end
-
-      href = if options[:hashtag_url_block]
-        options[:hashtag_url_block].call(hashtag)
-      else
-        "#{options[:hashtag_url_base]}#{hashtag}"
-      end
-
-      html_attrs = {
-        :class => hashtag_class,
-        # FIXME As our conformance test, hash in title should be half-width,
-        # this should be bug of conformance data.
-        :title => "##{hashtag}"
-      }.merge(options[:html_attrs])
-
-      link_to_text_with_symbol(entity, hash, hashtag, href, html_attrs, options)
-    end
-
-    def link_to_cashtag(entity, chars, options = {})
-      dollar = chars[entity[:indices].first]
-      cashtag = entity[:cashtag]
-      cashtag = yield(cashtag) if block_given?
-
-      href = if options[:cashtag_url_block]
-        options[:cashtag_url_block].call(cashtag)
-      else
-        "#{options[:cashtag_url_base]}#{cashtag}"
-      end
-
-      html_attrs = {
-        :class => "#{options[:cashtag_class]}",
-        :title => "$#{cashtag}"
-      }.merge(options[:html_attrs])
-
-      link_to_text_with_symbol(entity, dollar, cashtag, href, html_attrs, options)
-    end
-
-    def link_to_screen_name(entity, chars, options = {})
-      name  = "#{entity[:screen_name]}#{entity[:list_slug]}"
-
-      chunk = name.dup
-      chunk = yield(chunk) if block_given?
-
-      at = chars[entity[:indices].first]
-
-      html_attrs = options[:html_attrs].dup
-
-      if entity[:list_slug] && !entity[:list_slug].empty? && !options[:suppress_lists]
-        href = if options[:list_url_block]
-          options[:list_url_block].call(name)
-        else
-          "#{options[:list_url_base]}#{name}"
-        end
-        html_attrs[:class] ||= "#{options[:list_class]}"
-      else
-        href = if options[:username_url_block]
-          options[:username_url_block].call(chunk)
-        else
-          "#{options[:username_url_base]}#{name}"
-        end
-        html_attrs[:class] ||= "#{options[:username_class]}"
-      end
-
-      link_to_text_with_symbol(entity, at, chunk, href, html_attrs, options)
-    end
-
-    def link_to_text_with_symbol(entity, symbol, text, href, attributes = {}, options = {})
-      tagged_symbol = options[:symbol_tag] ? "<#{options[:symbol_tag]}>#{symbol}</#{options[:symbol_tag]}>" : symbol
-      text = html_escape(text)
-      tagged_text = options[:text_with_symbol_tag] ? "<#{options[:text_with_symbol_tag]}>#{text}</#{options[:text_with_symbol_tag]}>" : text
-      if options[:username_include_symbol] || symbol !~ Twitter::Regex::REGEXEN[:at_signs]
-        "#{link_to_text(entity, tagged_symbol + tagged_text, href, attributes, options)}"
-      else
-        "#{tagged_symbol}#{link_to_text(entity, tagged_text, href, attributes, options)}"
-      end
-    end
-
-    def link_to_text(entity, text, href, attributes = {}, options = {})
-      attributes[:href] = href
-      options[:link_attribute_block].call(entity, attributes) if options[:link_attribute_block]
-      text = options[:link_text_block].call(entity, text) if options[:link_text_block]
-      %(<a#{tag_attrs(attributes)}>#{text}</a>)
-    end
-
-    BOOLEAN_ATTRIBUTES = Set.new([:disabled, :readonly, :multiple, :checked]).freeze
-
-    def tag_attrs(attributes)
-      attributes.keys.sort_by{|k| k.to_s}.inject("") do |attrs, key|
-        value = attributes[key]
-
-        if BOOLEAN_ATTRIBUTES.include?(key)
-          value = value ? key : nil
+        entities.map! do |entity|
+          entity = HashHelper.symbolize_keys(entity)
+          # hashtag
+          entity[:hashtag] = entity[:text] if entity[:text]
+          entity
         end
 
-        unless value.nil?
-          value = case value
-          when Array
-            value.compact.join(" ")
-          else
-            value
+        auto_link_entities(text, entities, options)
+      end
+
+      def auto_link_entities(text, entities, options = {}, &block)
+        return text if entities.empty?
+
+        # NOTE deprecate these attributes not options keys in options hash, then use html_attrs
+        options = DEFAULT_OPTIONS.merge(options)
+        options[:html_attrs] = extract_html_attrs_from_options!(options)
+        options[:html_attrs][:rel] ||= "nofollow" unless options[:suppress_no_follow]
+        options[:html_attrs][:target] = "_blank" if options[:target_blank] == true
+
+        Twitter::TwitterText::Rewriter.rewrite_entities(text.dup, entities) do |entity, chars|
+          if entity[:url]
+            link_to_url(entity, chars, options, &block)
+          elsif entity[:hashtag]
+            link_to_hashtag(entity, chars, options, &block)
+          elsif entity[:screen_name]
+            link_to_screen_name(entity, chars, options, &block)
+          elsif entity[:cashtag]
+            link_to_cashtag(entity, chars, options, &block)
           end
-          attrs << %( #{html_escape(key)}="#{html_escape(value)}")
+        end
+      end
+
+      # Add <tt><a></a></tt> tags around the usernames, lists, hashtags and URLs in the provided <tt>text</tt>.
+      # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash:
+      # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
+      # and place in the <tt><a></tt> tag.
+      #
+      # <tt>:url_class</tt>::      class to add to url <tt><a></tt> tags
+      # <tt>:list_class</tt>::     class to add to list <tt><a></tt> tags
+      # <tt>:username_class</tt>:: class to add to username <tt><a></tt> tags
+      # <tt>:hashtag_class</tt>::  class to add to hashtag <tt><a></tt> tags
+      # <tt>:cashtag_class</tt>::  class to add to cashtag <tt><a></tt> tags
+      # <tt>:username_url_base</tt>::  the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
+      # <tt>:list_url_base</tt>::      the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
+      # <tt>:hashtag_url_base</tt>::   the value for <tt>href</tt> attribute on hashtag links. The <tt>#hashtag</tt> (minus the <tt>#</tt>) will be appended at the end of this.
+      # <tt>:cashtag_url_base</tt>::   the value for <tt>href</tt> attribute on cashtag links. The <tt>$cashtag</tt> (minus the <tt>$</tt>) will be appended at the end of this.
+      # <tt>:invisible_tag_attrs</tt>::   HTML attribute to add to invisible span tags
+      # <tt>:username_include_symbol</tt>:: place the <tt>@</tt> symbol within username and list links
+      # <tt>:suppress_lists</tt>::          disable auto-linking to lists
+      # <tt>:suppress_no_follow</tt>::      do not add <tt>rel="nofollow"</tt> to auto-linked items
+      # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+      # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+      # <tt>:url_target</tt>::     the value for <tt>target</tt> attribute on URL links.
+      # <tt>:target_blank</tt>:: adds <tt>target="_blank"</tt> to all auto_linked items username / hashtag / cashtag links / urls
+      # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+      # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
+      def auto_link(text, options = {}, &block)
+        auto_link_entities(text, Extractor.extract_entities_with_indices(text, :extract_url_without_protocol => false), options, &block)
+      end
+
+      # Add <tt><a></a></tt> tags around the usernames and lists in the provided <tt>text</tt>. The
+      # <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
+      # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
+      # and place in the <tt><a></tt> tag.
+      #
+      # <tt>:list_class</tt>::     class to add to list <tt><a></tt> tags
+      # <tt>:username_class</tt>:: class to add to username <tt><a></tt> tags
+      # <tt>:username_url_base</tt>:: the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
+      # <tt>:list_url_base</tt>::     the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
+      # <tt>:username_include_symbol</tt>:: place the <tt>@</tt> symbol within username and list links
+      # <tt>:suppress_lists</tt>::          disable auto-linking to lists
+      # <tt>:suppress_no_follow</tt>::      do not add <tt>rel="nofollow"</tt> to auto-linked items
+      # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+      # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+      # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+      # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
+      def auto_link_usernames_or_lists(text, options = {}, &block) # :yields: list_or_username
+        auto_link_entities(text, Extractor.extract_mentions_or_lists_with_indices(text), options, &block)
+      end
+
+      # Add <tt><a></a></tt> tags around the hashtags in the provided <tt>text</tt>.
+      # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
+      # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
+      # and place in the <tt><a></tt> tag.
+      #
+      # <tt>:hashtag_class</tt>:: class to add to hashtag <tt><a></tt> tags
+      # <tt>:hashtag_url_base</tt>:: the value for <tt>href</tt> attribute. The hashtag text (minus the <tt>#</tt>) will be appended at the end of this.
+      # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
+      # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+      # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+      # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+      # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
+      def auto_link_hashtags(text, options = {}, &block)  # :yields: hashtag_text
+        auto_link_entities(text, Extractor.extract_hashtags_with_indices(text), options, &block)
+      end
+
+      # Add <tt><a></a></tt> tags around the cashtags in the provided <tt>text</tt>.
+      # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
+      # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
+      # and place in the <tt><a></tt> tag.
+      #
+      # <tt>:cashtag_class</tt>:: class to add to cashtag <tt><a></tt> tags
+      # <tt>:cashtag_url_base</tt>:: the value for <tt>href</tt> attribute. The cashtag text (minus the <tt>$</tt>) will be appended at the end of this.
+      # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
+      # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+      # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+      # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+      # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
+      def auto_link_cashtags(text, options = {}, &block)  # :yields: cashtag_text
+        auto_link_entities(text, Extractor.extract_cashtags_with_indices(text), options, &block)
+      end
+
+      # Add <tt><a></a></tt> tags around the URLs in the provided <tt>text</tt>.
+      # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
+      # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
+      # and place in the <tt><a></tt> tag.
+      #
+      # <tt>:url_class</tt>::     class to add to url <tt><a></tt> tags
+      # <tt>:invisible_tag_attrs</tt>::   HTML attribute to add to invisible span tags
+      # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
+      # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+      # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+      # <tt>:url_target</tt>::     the value for <tt>target</tt> attribute on URL links.
+      # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+      # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
+      def auto_link_urls(text, options = {}, &block)
+        auto_link_entities(text, Extractor.extract_urls_with_indices(text, :extract_url_without_protocol => false), options, &block)
+      end
+
+      # These methods are deprecated, will be removed in future.
+      extend Deprecation
+
+      # <b>Deprecated</b>: Please use auto_link_urls instead.
+      # Add <tt><a></a></tt> tags around the URLs in the provided <tt>text</tt>.
+      # Any elements in the <tt>href_options</tt> hash will be converted to HTML attributes
+      # and place in the <tt><a></tt> tag.
+      # Unless <tt>href_options</tt> contains <tt>:suppress_no_follow</tt>
+      # the <tt>rel="nofollow"</tt> attribute will be added.
+      alias :auto_link_urls_custom :auto_link_urls
+      deprecate :auto_link_urls_custom, :auto_link_urls
+
+      private
+
+      HTML_ENTITIES = {
+        '&' => '&amp;',
+        '>' => '&gt;',
+        '<' => '&lt;',
+        '"' => '&quot;',
+        "'" => '&#39;'
+      }
+
+      def html_escape(text)
+        text && text.to_s.gsub(/[&"'><]/) do |character|
+          HTML_ENTITIES[character]
+        end
+      end
+
+      # NOTE We will make this private in future.
+      public :html_escape
+
+      # Options which should not be passed as HTML attributes
+      OPTIONS_NOT_ATTRIBUTES = Set.new([
+                                         :url_class, :list_class, :username_class, :hashtag_class, :cashtag_class,
+                                         :username_url_base, :list_url_base, :hashtag_url_base, :cashtag_url_base,
+                                         :username_url_block, :list_url_block, :hashtag_url_block, :cashtag_url_block, :link_url_block,
+                                         :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities,
+                                         :invisible_tag_attrs, :symbol_tag, :text_with_symbol_tag, :url_target, :target_blank,
+                                         :link_attribute_block, :link_text_block
+                                       ]).freeze
+
+      def extract_html_attrs_from_options!(options)
+        html_attrs = {}
+        options.reject! do |key, value|
+          unless OPTIONS_NOT_ATTRIBUTES.include?(key)
+            html_attrs[key] = value
+            true
+          end
+        end
+        html_attrs
+      end
+
+      def url_entities_hash(url_entities)
+        (url_entities || {}).inject({}) do |entities, entity|
+          # be careful not to alter arguments received
+          _entity = HashHelper.symbolize_keys(entity)
+          entities[_entity[:url]] = _entity
+          entities
+        end
+      end
+
+      def link_to_url(entity, chars, options = {})
+        url = entity[:url]
+
+        href = if options[:link_url_block]
+                 options[:link_url_block].call(url)
+               else
+                 url
+               end
+
+        # NOTE auto link to urls do not use any default values and options
+        # like url_class but use suppress_no_follow.
+        html_attrs = options[:html_attrs].dup
+        html_attrs[:class] = options[:url_class] if options.key?(:url_class)
+
+        # add target attribute only if :url_target is specified
+        html_attrs[:target] = options[:url_target] if options.key?(:url_target)
+
+        url_entities = url_entities_hash(options[:url_entities])
+
+        # use entity from urlEntities if available
+        url_entity = url_entities[url] || entity
+        link_text = if url_entity[:display_url]
+                      html_attrs[:title] ||= url_entity[:expanded_url]
+                      link_url_with_entity(url_entity, options)
+                    else
+                      html_escape(url)
+                    end
+
+        link_to_text(entity, link_text, href, html_attrs, options)
+      end
+
+      def link_url_with_entity(entity, options)
+        display_url = entity[:display_url]
+        expanded_url = entity[:expanded_url]
+        invisible_tag_attrs = options[:invisible_tag_attrs] || DEFAULT_INVISIBLE_TAG_ATTRS
+
+        # Goal: If a user copies and pastes a tweet containing t.co'ed link, the resulting paste
+        # should contain the full original URL (expanded_url), not the display URL.
+        #
+        # Method: Whenever possible, we actually emit HTML that contains expanded_url, and use
+        # font-size:0 to hide those parts that should not be displayed (because they are not part of display_url).
+        # Elements with font-size:0 get copied even though they are not visible.
+        # Note that display:none doesn't work here. Elements with display:none don't get copied.
+        #
+        # Additionally, we want to *display* ellipses, but we don't want them copied.  To make this happen we
+        # wrap the ellipses in a tco-ellipsis class and provide an onCopy handler that sets display:none on
+        # everything with the tco-ellipsis class.
+        #
+        # Exception: pic.twitter.com images, for which expandedUrl = "https://twitter.com/username/status/1234/photo/1
+        # For those URLs, display_url is not a substring of expanded_url, so we don't do anything special to render the elided parts.
+        # For a pic.twitter.com URL, the only elided part will be the "https://", so this is fine.
+        display_url_sans_ellipses = display_url.gsub("…", "")
+
+        if expanded_url.include?(display_url_sans_ellipses)
+          before_display_url, after_display_url = expanded_url.split(display_url_sans_ellipses, 2)
+          preceding_ellipsis = /\A…/.match(display_url).to_s
+          following_ellipsis = /…\z/.match(display_url).to_s
+
+          # As an example: The user tweets "hi http://longdomainname.com/foo"
+          # This gets shortened to "hi http://t.co/xyzabc", with display_url = "…nname.com/foo"
+          # This will get rendered as:
+          # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
+          #   …
+          #   <!-- There's a chance the onCopy event handler might not fire. In case that happens,
+          #        we include an &nbsp; here so that the … doesn't bump up against the URL and ruin it.
+          #        The &nbsp; is inside the tco-ellipsis span so that when the onCopy handler *does*
+          #        fire, it doesn't get copied.  Otherwise the copied text would have two spaces in a row,
+          #        e.g. "hi  http://longdomainname.com/foo".
+          #   <span style='font-size:0'>&nbsp;</span>
+          # </span>
+          # <span style='font-size:0'>  <!-- This stuff should get copied but not displayed -->
+          #   http://longdomai
+          # </span>
+          # <span class='js-display-url'> <!-- This stuff should get displayed *and* copied -->
+          #   nname.com/foo
+          # </span>
+          # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
+          #   <span style='font-size:0'>&nbsp;</span>
+          #   …
+          # </span>
+          %(<span class="tco-ellipsis">#{preceding_ellipsis}<span #{invisible_tag_attrs}>&nbsp;</span></span>) <<
+            %(<span #{invisible_tag_attrs}>#{html_escape(before_display_url)}</span>) <<
+            %(<span class="js-display-url">#{html_escape(display_url_sans_ellipses)}</span>) <<
+            %(<span #{invisible_tag_attrs}>#{html_escape(after_display_url)}</span>) <<
+            %(<span class="tco-ellipsis"><span #{invisible_tag_attrs}>&nbsp;</span>#{following_ellipsis}</span>)
+        else
+          html_escape(display_url)
+        end
+      end
+
+      def link_to_hashtag(entity, chars, options = {})
+        hash = chars[entity[:indices].first]
+        hashtag = entity[:hashtag]
+        hashtag = yield(hashtag) if block_given?
+        hashtag_class = options[:hashtag_class].to_s
+
+        if hashtag.match Twitter::TwitterText::Regex::REGEXEN[:rtl_chars]
+          hashtag_class += ' rtl'
         end
 
-        attrs
+        href = if options[:hashtag_url_block]
+                 options[:hashtag_url_block].call(hashtag)
+               else
+                 "#{options[:hashtag_url_base]}#{hashtag}"
+               end
+
+        html_attrs = {
+          :class => hashtag_class,
+          # FIXME As our conformance test, hash in title should be half-width,
+          # this should be bug of conformance data.
+          :title => "##{hashtag}"
+        }.merge(options[:html_attrs])
+
+        link_to_text_with_symbol(entity, hash, hashtag, href, html_attrs, options)
+      end
+
+      def link_to_cashtag(entity, chars, options = {})
+        dollar = chars[entity[:indices].first]
+        cashtag = entity[:cashtag]
+        cashtag = yield(cashtag) if block_given?
+
+        href = if options[:cashtag_url_block]
+                 options[:cashtag_url_block].call(cashtag)
+               else
+                 "#{options[:cashtag_url_base]}#{cashtag}"
+               end
+
+        html_attrs = {
+          :class => "#{options[:cashtag_class]}",
+          :title => "$#{cashtag}"
+        }.merge(options[:html_attrs])
+
+        link_to_text_with_symbol(entity, dollar, cashtag, href, html_attrs, options)
+      end
+
+      def link_to_screen_name(entity, chars, options = {})
+        name  = "#{entity[:screen_name]}#{entity[:list_slug]}"
+
+        chunk = name.dup
+        chunk = yield(chunk) if block_given?
+
+        at = chars[entity[:indices].first]
+
+        html_attrs = options[:html_attrs].dup
+
+        if entity[:list_slug] && !entity[:list_slug].empty? && !options[:suppress_lists]
+          href = if options[:list_url_block]
+                   options[:list_url_block].call(name)
+                 else
+                   "#{options[:list_url_base]}#{name}"
+                 end
+          html_attrs[:class] ||= "#{options[:list_class]}"
+        else
+          href = if options[:username_url_block]
+                   options[:username_url_block].call(chunk)
+                 else
+                   "#{options[:username_url_base]}#{name}"
+                 end
+          html_attrs[:class] ||= "#{options[:username_class]}"
+        end
+
+        link_to_text_with_symbol(entity, at, chunk, href, html_attrs, options)
+      end
+
+      def link_to_text_with_symbol(entity, symbol, text, href, attributes = {}, options = {})
+        tagged_symbol = options[:symbol_tag] ? "<#{options[:symbol_tag]}>#{symbol}</#{options[:symbol_tag]}>" : symbol
+        text = html_escape(text)
+        tagged_text = options[:text_with_symbol_tag] ? "<#{options[:text_with_symbol_tag]}>#{text}</#{options[:text_with_symbol_tag]}>" : text
+        if options[:username_include_symbol] || symbol !~ Twitter::TwitterText::Regex::REGEXEN[:at_signs]
+          "#{link_to_text(entity, tagged_symbol + tagged_text, href, attributes, options)}"
+        else
+          "#{tagged_symbol}#{link_to_text(entity, tagged_text, href, attributes, options)}"
+        end
+      end
+
+      def link_to_text(entity, text, href, attributes = {}, options = {})
+        attributes[:href] = href
+        options[:link_attribute_block].call(entity, attributes) if options[:link_attribute_block]
+        text = options[:link_text_block].call(entity, text) if options[:link_text_block]
+        %(<a#{tag_attrs(attributes)}>#{text}</a>)
+      end
+
+      BOOLEAN_ATTRIBUTES = Set.new([:disabled, :readonly, :multiple, :checked]).freeze
+
+      def tag_attrs(attributes)
+        attributes.keys.sort_by{|k| k.to_s}.inject("") do |attrs, key|
+          value = attributes[key]
+
+          if BOOLEAN_ATTRIBUTES.include?(key)
+            value = value ? key : nil
+          end
+
+          unless value.nil?
+            value = case value
+                    when Array
+                      value.compact.join(" ")
+                    else
+                      value
+                    end
+            attrs << %( #{html_escape(key)}="#{html_escape(value)}")
+          end
+
+          attrs
+        end
       end
     end
-
   end
 end

--- a/rb/lib/twitter-text/configuration.rb
+++ b/rb/lib/twitter-text/configuration.rb
@@ -1,53 +1,54 @@
 # encoding: UTF-8
 
 module Twitter
-  class Configuration
-    require 'json'
+  module TwitterText
+    class Configuration
+      require 'json'
 
-    PARSER_VERSION_CLASSIC = "v1"
-    PARSER_VERSION_DEFAULT = "v2"
+      PARSER_VERSION_CLASSIC = "v1"
+      PARSER_VERSION_DEFAULT = "v2"
 
-    class << self
-      attr_accessor :default_configuration
+      class << self
+        attr_accessor :default_configuration
+      end
+
+      attr_reader :version, :max_weighted_tweet_length, :scale
+      attr_reader :default_weight, :transformed_url_length, :ranges
+
+      CONFIG_V1 = File.join(
+        File.expand_path('../../../config', __FILE__), # project root
+        "#{PARSER_VERSION_CLASSIC}.json"
+      )
+
+      CONFIG_V2 = File.join(
+        File.expand_path('../../../config', __FILE__), # project root
+        "#{PARSER_VERSION_DEFAULT}.json"
+      )
+
+      def self.parse_string(string, options = {})
+        JSON.parse(string, options.merge(symbolize_names: true))
+      end
+
+      def self.parse_file(filename)
+        string = File.open(filename, 'rb') { |f| f.read }
+        parse_string(string)
+      end
+
+      def self.configuration_from_file(filename)
+        config = parse_file(filename)
+        config ? self.new(config) : nil
+      end
+
+      def initialize(config = {})
+        @version = config[:version]
+        @max_weighted_tweet_length = config[:maxWeightedTweetLength]
+        @scale = config[:scale]
+        @default_weight = config[:defaultWeight]
+        @transformed_url_length = config[:transformedURLLength]
+        @ranges = config[:ranges].map { |range| Twitter::TwitterText::WeightedRange.new(range) } if config.key?(:ranges) && config[:ranges].is_a?(Array)
+      end
+
+      self.default_configuration = self.configuration_from_file(CONFIG_V2)
     end
-
-    attr_reader :version, :max_weighted_tweet_length, :scale
-    attr_reader :default_weight, :transformed_url_length, :ranges
-
-    CONFIG_V1 = File.join(
-      File.expand_path('../../../config', __FILE__), # project root
-      "#{PARSER_VERSION_CLASSIC}.json"
-    )
-
-    CONFIG_V2 = File.join(
-      File.expand_path('../../../config', __FILE__), # project root
-      "#{PARSER_VERSION_DEFAULT}.json"
-    )
-
-    def self.parse_string(string, options = {})
-      JSON.parse(string, options.merge(symbolize_names: true))
-    end
-
-    def self.parse_file(filename)
-      string = File.open(filename, 'rb') { |f| f.read }
-      parse_string(string)
-    end
-
-    def self.configuration_from_file(filename)
-      config = parse_file(filename)
-      config ? Twitter::Configuration.new(config) : nil
-    end
-
-    def initialize(config = {})
-      @version = config[:version]
-      @max_weighted_tweet_length = config[:maxWeightedTweetLength]
-      @scale = config[:scale]
-      @default_weight = config[:defaultWeight]
-      @transformed_url_length = config[:transformedURLLength]
-      @ranges = config[:ranges].map { |range| Twitter::WeightedRange.new(range) } if config.key?(:ranges) && config[:ranges].is_a?(Array)
-    end
-
-    self.default_configuration = Twitter::Configuration.configuration_from_file(Twitter::Configuration::CONFIG_V2)
   end
 end
-

--- a/rb/lib/twitter-text/deprecation.rb
+++ b/rb/lib/twitter-text/deprecation.rb
@@ -1,14 +1,16 @@
 module Twitter
-  module Deprecation
-    def deprecate(method, new_method = nil)
-      deprecated_method = :"deprecated_#{method}"
-      message = "Deprecation: `#{method}` is deprecated."
-      message << " Please use `#{new_method}` instead." if new_method
+  module TwitterText
+    module Deprecation
+      def deprecate(method, new_method = nil)
+        deprecated_method = :"deprecated_#{method}"
+        message = "Deprecation: `#{method}` is deprecated."
+        message << " Please use `#{new_method}` instead." if new_method
 
-      alias_method(deprecated_method, method)
-      define_method method do |*args, &block|
-        warn message unless $TESTING
-        send(deprecated_method, *args, &block)
+        alias_method(deprecated_method, method)
+        define_method method do |*args, &block|
+          warn message unless $TESTING
+          send(deprecated_method, *args, &block)
+        end
       end
     end
   end

--- a/rb/lib/twitter-text/extractor.rb
+++ b/rb/lib/twitter-text/extractor.rb
@@ -45,313 +45,315 @@ class MatchData
 end
 
 module Twitter
-  # A module for including Tweet parsing in a class. This module provides function for the extraction and processing
-  # of usernames, lists, URLs and hashtags.
-  module Extractor extend self
+  module TwitterText
+    # A module for including Tweet parsing in a class. This module provides function for the extraction and processing
+    # of usernames, lists, URLs and hashtags.
+    module Extractor extend self
 
-    # Maximum URL length as defined by Twitter's backend.
-    MAX_URL_LENGTH = 4096
+      # Maximum URL length as defined by Twitter's backend.
+      MAX_URL_LENGTH = 4096
 
-    # The maximum t.co path length that the Twitter backend supports.
-    MAX_TCO_SLUG_LENGTH = 40
+      # The maximum t.co path length that the Twitter backend supports.
+      MAX_TCO_SLUG_LENGTH = 40
 
-    URL_PROTOCOL_LENGTH = "https://".length
+      URL_PROTOCOL_LENGTH = "https://".length
 
-    # Remove overlapping entities.
-    # This returns a new array with no overlapping entities.
-    def remove_overlapping_entities(entities)
-      # sort by start index
-      entities = entities.sort_by{|entity| entity[:indices].first}
+      # Remove overlapping entities.
+      # This returns a new array with no overlapping entities.
+      def remove_overlapping_entities(entities)
+        # sort by start index
+        entities = entities.sort_by{|entity| entity[:indices].first}
 
-      # remove duplicates
-      prev = nil
-      entities.reject!{|entity| (prev && prev[:indices].last > entity[:indices].first) || (prev = entity) && false}
-      entities
-    end
-
-    # Extracts all usernames, lists, hashtags and URLs  in the Tweet <tt>text</tt>
-    # along with the indices for where the entity ocurred
-    # If the <tt>text</tt> is <tt>nil</tt> or contains no entity an empty array
-    # will be returned.
-    #
-    # If a block is given then it will be called for each entity.
-    def extract_entities_with_indices(text, options = {}, &block)
-      # extract all entities
-      entities = extract_urls_with_indices(text, options) +
-                 extract_hashtags_with_indices(text, :check_url_overlap => false) +
-                 extract_mentions_or_lists_with_indices(text) +
-                 extract_cashtags_with_indices(text)
-
-      return [] if entities.empty?
-
-      entities = remove_overlapping_entities(entities)
-
-      entities.each(&block) if block_given?
-      entities
-    end
-
-    # Extracts a list of all usernames mentioned in the Tweet <tt>text</tt>. If the
-    # <tt>text</tt> is <tt>nil</tt> or contains no username mentions an empty array
-    # will be returned.
-    #
-    # If a block is given then it will be called for each username.
-    def extract_mentioned_screen_names(text, &block) # :yields: username
-      screen_names = extract_mentioned_screen_names_with_indices(text).map{|m| m[:screen_name]}
-      screen_names.each(&block) if block_given?
-      screen_names
-    end
-
-    # Extracts a list of all usernames mentioned in the Tweet <tt>text</tt>
-    # along with the indices for where the mention ocurred.  If the
-    # <tt>text</tt> is nil or contains no username mentions, an empty array
-    # will be returned.
-    #
-    # If a block is given, then it will be called with each username, the start
-    # index, and the end index in the <tt>text</tt>.
-    def extract_mentioned_screen_names_with_indices(text) # :yields: username, start, end
-      return [] unless text
-
-      possible_screen_names = []
-      extract_mentions_or_lists_with_indices(text) do |screen_name, list_slug, start_position, end_position|
-        next unless list_slug.empty?
-        possible_screen_names << {
-          :screen_name => screen_name,
-          :indices => [start_position, end_position]
-        }
+        # remove duplicates
+        prev = nil
+        entities.reject!{|entity| (prev && prev[:indices].last > entity[:indices].first) || (prev = entity) && false}
+        entities
       end
 
-      if block_given?
-        possible_screen_names.each do |mention|
-          yield mention[:screen_name], mention[:indices].first, mention[:indices].last
-        end
+      # Extracts all usernames, lists, hashtags and URLs  in the Tweet <tt>text</tt>
+      # along with the indices for where the entity ocurred
+      # If the <tt>text</tt> is <tt>nil</tt> or contains no entity an empty array
+      # will be returned.
+      #
+      # If a block is given then it will be called for each entity.
+      def extract_entities_with_indices(text, options = {}, &block)
+        # extract all entities
+        entities = extract_urls_with_indices(text, options) +
+                   extract_hashtags_with_indices(text, :check_url_overlap => false) +
+                   extract_mentions_or_lists_with_indices(text) +
+                   extract_cashtags_with_indices(text)
+
+        return [] if entities.empty?
+
+        entities = remove_overlapping_entities(entities)
+
+        entities.each(&block) if block_given?
+        entities
       end
 
-      possible_screen_names
-    end
+      # Extracts a list of all usernames mentioned in the Tweet <tt>text</tt>. If the
+      # <tt>text</tt> is <tt>nil</tt> or contains no username mentions an empty array
+      # will be returned.
+      #
+      # If a block is given then it will be called for each username.
+      def extract_mentioned_screen_names(text, &block) # :yields: username
+        screen_names = extract_mentioned_screen_names_with_indices(text).map{|m| m[:screen_name]}
+        screen_names.each(&block) if block_given?
+        screen_names
+      end
 
-    # Extracts a list of all usernames or lists mentioned in the Tweet <tt>text</tt>
-    # along with the indices for where the mention ocurred.  If the
-    # <tt>text</tt> is nil or contains no username or list mentions, an empty array
-    # will be returned.
-    #
-    # If a block is given, then it will be called with each username, list slug, the start
-    # index, and the end index in the <tt>text</tt>. The list_slug will be an empty stirng
-    # if this is a username mention.
-    def extract_mentions_or_lists_with_indices(text) # :yields: username, list_slug, start, end
-      return [] unless text =~ /[@＠]/
+      # Extracts a list of all usernames mentioned in the Tweet <tt>text</tt>
+      # along with the indices for where the mention ocurred.  If the
+      # <tt>text</tt> is nil or contains no username mentions, an empty array
+      # will be returned.
+      #
+      # If a block is given, then it will be called with each username, the start
+      # index, and the end index in the <tt>text</tt>.
+      def extract_mentioned_screen_names_with_indices(text) # :yields: username, start, end
+        return [] unless text
 
-      possible_entries = []
-      text.to_s.scan(Twitter::Regex[:valid_mention_or_list]) do |before, at, screen_name, list_slug|
-        match_data = $~
-        after = $'
-        unless after =~ Twitter::Regex[:end_mention_match]
-          start_position = match_data.char_begin(3) - 1
-          end_position = match_data.char_end(list_slug.nil? ? 3 : 4)
-          possible_entries << {
+        possible_screen_names = []
+        extract_mentions_or_lists_with_indices(text) do |screen_name, list_slug, start_position, end_position|
+          next unless list_slug.empty?
+          possible_screen_names << {
             :screen_name => screen_name,
-            :list_slug => list_slug || "",
             :indices => [start_position, end_position]
           }
         end
-      end
 
-      if block_given?
-        possible_entries.each do |mention|
-          yield mention[:screen_name], mention[:list_slug], mention[:indices].first, mention[:indices].last
+        if block_given?
+          possible_screen_names.each do |mention|
+            yield mention[:screen_name], mention[:indices].first, mention[:indices].last
+          end
         end
+
+        possible_screen_names
       end
 
-      possible_entries
-    end
+      # Extracts a list of all usernames or lists mentioned in the Tweet <tt>text</tt>
+      # along with the indices for where the mention ocurred.  If the
+      # <tt>text</tt> is nil or contains no username or list mentions, an empty array
+      # will be returned.
+      #
+      # If a block is given, then it will be called with each username, list slug, the start
+      # index, and the end index in the <tt>text</tt>. The list_slug will be an empty stirng
+      # if this is a username mention.
+      def extract_mentions_or_lists_with_indices(text) # :yields: username, list_slug, start, end
+        return [] unless text =~ /[@＠]/
 
-    # Extracts the username username replied to in the Tweet <tt>text</tt>. If the
-    # <tt>text</tt> is <tt>nil</tt> or is not a reply nil will be returned.
-    #
-    # If a block is given then it will be called with the username replied to (if any)
-    def extract_reply_screen_name(text) # :yields: username
-      return nil unless text
-
-      possible_screen_name = text.match(Twitter::Regex[:valid_reply])
-      return unless possible_screen_name.respond_to?(:captures)
-      return if $' =~ Twitter::Regex[:end_mention_match]
-      screen_name = possible_screen_name.captures.first
-      yield screen_name if block_given?
-      screen_name
-    end
-
-    # Extracts a list of all URLs included in the Tweet <tt>text</tt>. If the
-    # <tt>text</tt> is <tt>nil</tt> or contains no URLs an empty array
-    # will be returned.
-    #
-    # If a block is given then it will be called for each URL.
-    def extract_urls(text, &block) # :yields: url
-      urls = extract_urls_with_indices(text).map{|u| u[:url]}
-      urls.each(&block) if block_given?
-      urls
-    end
-
-    # Extracts a list of all URLs included in the Tweet <tt>text</tt> along
-    # with the indices. If the <tt>text</tt> is <tt>nil</tt> or contains no
-    # URLs an empty array will be returned.
-    #
-    # If a block is given then it will be called for each URL.
-    def extract_urls_with_indices(text, options = {:extract_url_without_protocol => true}) # :yields: url, start, end
-      return [] unless text && (options[:extract_url_without_protocol] ? text.index(".") : text.index(":"))
-      urls = []
-
-      text.to_s.scan(Twitter::Regex[:valid_url]) do |all, before, url, protocol, domain, port, path, query|
-        valid_url_match_data = $~
-
-        start_position = valid_url_match_data.char_begin(3)
-        end_position = valid_url_match_data.char_end(3)
-
-        # If protocol is missing and domain contains non-ASCII characters,
-        # extract ASCII-only domains.
-        if !protocol
-          next if !options[:extract_url_without_protocol] || before =~ Twitter::Regex[:invalid_url_without_protocol_preceding_chars]
-          last_url = nil
-          domain.scan(Twitter::Regex[:valid_ascii_domain]) do |ascii_domain|
-            next unless is_valid_domain(url.length, ascii_domain, protocol)
-            last_url = {
-              :url => ascii_domain,
-              :indices => [start_position + $~.char_begin(0),
-                           start_position + $~.char_end(0)]
+        possible_entries = []
+        text.to_s.scan(Twitter::TwitterText::Regex[:valid_mention_or_list]) do |before, at, screen_name, list_slug|
+          match_data = $~
+                        after = $'
+          unless after =~ Twitter::TwitterText::Regex[:end_mention_match]
+            start_position = match_data.char_begin(3) - 1
+            end_position = match_data.char_end(list_slug.nil? ? 3 : 4)
+            possible_entries << {
+              :screen_name => screen_name,
+              :list_slug => list_slug || "",
+              :indices => [start_position, end_position]
             }
-            if path ||
-                ascii_domain =~ Twitter::Regex[:valid_special_short_domain] ||
-                ascii_domain !~ Twitter::Regex[:invalid_short_domain]
-              urls << last_url
+          end
+        end
+
+        if block_given?
+          possible_entries.each do |mention|
+            yield mention[:screen_name], mention[:list_slug], mention[:indices].first, mention[:indices].last
+          end
+        end
+
+        possible_entries
+      end
+
+      # Extracts the username username replied to in the Tweet <tt>text</tt>. If the
+      # <tt>text</tt> is <tt>nil</tt> or is not a reply nil will be returned.
+      #
+      # If a block is given then it will be called with the username replied to (if any)
+      def extract_reply_screen_name(text) # :yields: username
+        return nil unless text
+
+        possible_screen_name = text.match(Twitter::TwitterText::Regex[:valid_reply])
+        return unless possible_screen_name.respond_to?(:captures)
+        return if $' =~ Twitter::TwitterText::Regex[:end_mention_match]
+        screen_name = possible_screen_name.captures.first
+        yield screen_name if block_given?
+        screen_name
+      end
+
+      # Extracts a list of all URLs included in the Tweet <tt>text</tt>. If the
+      # <tt>text</tt> is <tt>nil</tt> or contains no URLs an empty array
+      # will be returned.
+      #
+      # If a block is given then it will be called for each URL.
+      def extract_urls(text, &block) # :yields: url
+        urls = extract_urls_with_indices(text).map{|u| u[:url]}
+        urls.each(&block) if block_given?
+        urls
+      end
+
+      # Extracts a list of all URLs included in the Tweet <tt>text</tt> along
+      # with the indices. If the <tt>text</tt> is <tt>nil</tt> or contains no
+      # URLs an empty array will be returned.
+      #
+      # If a block is given then it will be called for each URL.
+      def extract_urls_with_indices(text, options = {:extract_url_without_protocol => true}) # :yields: url, start, end
+        return [] unless text && (options[:extract_url_without_protocol] ? text.index(".") : text.index(":"))
+        urls = []
+
+        text.to_s.scan(Twitter::TwitterText::Regex[:valid_url]) do |all, before, url, protocol, domain, port, path, query|
+          valid_url_match_data = $~
+
+                                  start_position = valid_url_match_data.char_begin(3)
+          end_position = valid_url_match_data.char_end(3)
+
+          # If protocol is missing and domain contains non-ASCII characters,
+          # extract ASCII-only domains.
+          if !protocol
+            next if !options[:extract_url_without_protocol] || before =~ Twitter::TwitterText::Regex[:invalid_url_without_protocol_preceding_chars]
+            last_url = nil
+            domain.scan(Twitter::TwitterText::Regex[:valid_ascii_domain]) do |ascii_domain|
+              next unless is_valid_domain(url.length, ascii_domain, protocol)
+              last_url = {
+                :url => ascii_domain,
+                :indices => [start_position + $~.char_begin(0),
+                             start_position + $~.char_end(0)]
+              }
+              if path ||
+                 ascii_domain =~ Twitter::TwitterText::Regex[:valid_special_short_domain] ||
+                 ascii_domain !~ Twitter::TwitterText::Regex[:invalid_short_domain]
+                urls << last_url
+              end
             end
+
+            # no ASCII-only domain found. Skip the entire URL
+            next unless last_url
+
+            # last_url only contains domain. Need to add path and query if they exist.
+            if path
+              # last_url was not added. Add it to urls here.
+              last_url[:url] = url.sub(domain, last_url[:url])
+              last_url[:indices][1] = end_position
+            end
+          else
+            # In the case of t.co URLs, don't allow additional path characters
+            if url =~ Twitter::TwitterText::Regex[:valid_tco_url]
+              next if $1 && $1.length > MAX_TCO_SLUG_LENGTH
+              url = $&
+                    end_position = start_position + url.char_length
+            end
+
+            next unless is_valid_domain(url.length, domain, protocol)
+
+            urls << {
+              :url => url,
+              :indices => [start_position, end_position]
+            }
           end
-
-          # no ASCII-only domain found. Skip the entire URL
-          next unless last_url
-
-          # last_url only contains domain. Need to add path and query if they exist.
-          if path
-            # last_url was not added. Add it to urls here.
-            last_url[:url] = url.sub(domain, last_url[:url])
-            last_url[:indices][1] = end_position
-          end
-        else
-          # In the case of t.co URLs, don't allow additional path characters
-          if url =~ Twitter::Regex[:valid_tco_url]
-            next if $1 && $1.length > MAX_TCO_SLUG_LENGTH
-            url = $&
-            end_position = start_position + url.char_length
-          end
-
-          next unless is_valid_domain(url.length, domain, protocol)
-
-          urls << {
-            :url => url,
-            :indices => [start_position, end_position]
-          }
         end
+        urls.each{|url| yield url[:url], url[:indices].first, url[:indices].last} if block_given?
+        urls
       end
-      urls.each{|url| yield url[:url], url[:indices].first, url[:indices].last} if block_given?
-      urls
-    end
 
-    # Extracts a list of all hashtags included in the Tweet <tt>text</tt>. If the
-    # <tt>text</tt> is <tt>nil</tt> or contains no hashtags an empty array
-    # will be returned. The array returned will not include the leading <tt>#</tt>
-    # character.
-    #
-    # If a block is given then it will be called for each hashtag.
-    def extract_hashtags(text, &block) # :yields: hashtag_text
-      hashtags = extract_hashtags_with_indices(text).map{|h| h[:hashtag]}
-      hashtags.each(&block) if block_given?
-      hashtags
-    end
+      # Extracts a list of all hashtags included in the Tweet <tt>text</tt>. If the
+      # <tt>text</tt> is <tt>nil</tt> or contains no hashtags an empty array
+      # will be returned. The array returned will not include the leading <tt>#</tt>
+      # character.
+      #
+      # If a block is given then it will be called for each hashtag.
+      def extract_hashtags(text, &block) # :yields: hashtag_text
+        hashtags = extract_hashtags_with_indices(text).map{|h| h[:hashtag]}
+        hashtags.each(&block) if block_given?
+        hashtags
+      end
 
-    # Extracts a list of all hashtags included in the Tweet <tt>text</tt>. If the
-    # <tt>text</tt> is <tt>nil</tt> or contains no hashtags an empty array
-    # will be returned. The array returned will not include the leading <tt>#</tt>
-    # character.
-    #
-    # If a block is given then it will be called for each hashtag.
-    def extract_hashtags_with_indices(text, options = {:check_url_overlap => true}) # :yields: hashtag_text, start, end
-      return [] unless text =~ /[#＃]/
+      # Extracts a list of all hashtags included in the Tweet <tt>text</tt>. If the
+      # <tt>text</tt> is <tt>nil</tt> or contains no hashtags an empty array
+      # will be returned. The array returned will not include the leading <tt>#</tt>
+      # character.
+      #
+      # If a block is given then it will be called for each hashtag.
+      def extract_hashtags_with_indices(text, options = {:check_url_overlap => true}) # :yields: hashtag_text, start, end
+        return [] unless text =~ /[#＃]/
 
-      tags = []
-      text.scan(Twitter::Regex[:valid_hashtag]) do |before, hash, hash_text|
-        match_data = $~
-        start_position = match_data.char_begin(2)
-        end_position = match_data.char_end(3)
-        after = $'
-        unless after =~ Twitter::Regex[:end_hashtag_match]
+        tags = []
+        text.scan(Twitter::TwitterText::Regex[:valid_hashtag]) do |before, hash, hash_text|
+          match_data = $~
+                        start_position = match_data.char_begin(2)
+          end_position = match_data.char_end(3)
+          after = $'
+          unless after =~ Twitter::TwitterText::Regex[:end_hashtag_match]
+            tags << {
+              :hashtag => hash_text,
+              :indices => [start_position, end_position]
+            }
+          end
+        end
+
+        if options[:check_url_overlap]
+          # extract URLs
+          urls = extract_urls_with_indices(text)
+          unless urls.empty?
+            tags.concat(urls)
+            # remove duplicates
+            tags = remove_overlapping_entities(tags)
+            # remove URL entities
+            tags.reject!{|entity| !entity[:hashtag] }
+          end
+        end
+
+        tags.each{|tag| yield tag[:hashtag], tag[:indices].first, tag[:indices].last} if block_given?
+        tags
+      end
+
+      # Extracts a list of all cashtags included in the Tweet <tt>text</tt>. If the
+      # <tt>text</tt> is <tt>nil</tt> or contains no cashtags an empty array
+      # will be returned. The array returned will not include the leading <tt>$</tt>
+      # character.
+      #
+      # If a block is given then it will be called for each cashtag.
+      def extract_cashtags(text, &block) # :yields: cashtag_text
+        cashtags = extract_cashtags_with_indices(text).map{|h| h[:cashtag]}
+        cashtags.each(&block) if block_given?
+        cashtags
+      end
+
+      # Extracts a list of all cashtags included in the Tweet <tt>text</tt>. If the
+      # <tt>text</tt> is <tt>nil</tt> or contains no cashtags an empty array
+      # will be returned. The array returned will not include the leading <tt>$</tt>
+      # character.
+      #
+      # If a block is given then it will be called for each cashtag.
+      def extract_cashtags_with_indices(text) # :yields: cashtag_text, start, end
+        return [] unless text =~ /\$/
+
+        tags = []
+        text.scan(Twitter::TwitterText::Regex[:valid_cashtag]) do |before, dollar, cash_text|
+          match_data = $~
+                        start_position = match_data.char_begin(2)
+          end_position = match_data.char_end(3)
           tags << {
-            :hashtag => hash_text,
+            :cashtag => cash_text,
             :indices => [start_position, end_position]
           }
         end
+
+        tags.each{|tag| yield tag[:cashtag], tag[:indices].first, tag[:indices].last} if block_given?
+        tags
       end
 
-      if options[:check_url_overlap]
-        # extract URLs
-        urls = extract_urls_with_indices(text)
-        unless urls.empty?
-          tags.concat(urls)
-          # remove duplicates
-          tags = remove_overlapping_entities(tags)
-          # remove URL entities
-          tags.reject!{|entity| !entity[:hashtag] }
+      def is_valid_domain(url_length, domain, protocol)
+        begin
+          raise ArgumentError.new("invalid empty domain") unless domain
+          original_domain_length = domain.length
+          encoded_domain = IDN::Idna.toASCII(domain)
+          updated_domain_length = encoded_domain.length
+          url_length += (updated_domain_length - original_domain_length) if (updated_domain_length > original_domain_length)
+          url_length += URL_PROTOCOL_LENGTH unless protocol
+          url_length <= MAX_URL_LENGTH
+        rescue Exception
+          # On error don't consider this a valid domain.
+          return false
         end
-      end
-
-      tags.each{|tag| yield tag[:hashtag], tag[:indices].first, tag[:indices].last} if block_given?
-      tags
-    end
-
-    # Extracts a list of all cashtags included in the Tweet <tt>text</tt>. If the
-    # <tt>text</tt> is <tt>nil</tt> or contains no cashtags an empty array
-    # will be returned. The array returned will not include the leading <tt>$</tt>
-    # character.
-    #
-    # If a block is given then it will be called for each cashtag.
-    def extract_cashtags(text, &block) # :yields: cashtag_text
-      cashtags = extract_cashtags_with_indices(text).map{|h| h[:cashtag]}
-      cashtags.each(&block) if block_given?
-      cashtags
-    end
-
-    # Extracts a list of all cashtags included in the Tweet <tt>text</tt>. If the
-    # <tt>text</tt> is <tt>nil</tt> or contains no cashtags an empty array
-    # will be returned. The array returned will not include the leading <tt>$</tt>
-    # character.
-    #
-    # If a block is given then it will be called for each cashtag.
-    def extract_cashtags_with_indices(text) # :yields: cashtag_text, start, end
-      return [] unless text =~ /\$/
-
-      tags = []
-      text.scan(Twitter::Regex[:valid_cashtag]) do |before, dollar, cash_text|
-        match_data = $~
-        start_position = match_data.char_begin(2)
-        end_position = match_data.char_end(3)
-        tags << {
-          :cashtag => cash_text,
-          :indices => [start_position, end_position]
-        }
-      end
-
-      tags.each{|tag| yield tag[:cashtag], tag[:indices].first, tag[:indices].last} if block_given?
-      tags
-    end
-
-    def is_valid_domain(url_length, domain, protocol)
-      begin
-        raise ArgumentError.new("invalid empty domain") unless domain
-        original_domain_length = domain.length
-        encoded_domain = IDN::Idna.toASCII(domain)
-        updated_domain_length = encoded_domain.length
-        url_length += (updated_domain_length - original_domain_length) if (updated_domain_length > original_domain_length)
-        url_length += URL_PROTOCOL_LENGTH unless protocol
-        url_length <= MAX_URL_LENGTH
-      rescue Exception
-        # On error don't consider this a valid domain.
-        return false
       end
     end
   end

--- a/rb/lib/twitter-text/hash_helper.rb
+++ b/rb/lib/twitter-text/hash_helper.rb
@@ -1,21 +1,23 @@
 module Twitter
-  module HashHelper
-    # Return a new hash with all keys converted to symbols, as long as
-    # they respond to +to_sym+.
-    #
-    #   { 'name' => 'Rob', 'years' => '28' }.symbolize_keys
-    #   #=> { :name => "Rob", :years => "28" }
-    def self.symbolize_keys(hash)
-      symbolize_keys!(hash.dup)
-    end
-
-    # Destructively convert all keys to symbols, as long as they respond
-    # to +to_sym+. Same as +symbolize_keys+, but modifies +self+.
-    def self.symbolize_keys!(hash)
-      hash.keys.each do |key|
-        hash[(key.to_sym rescue key) || key] = hash.delete(key)
+  module TwitterText
+    module HashHelper
+      # Return a new hash with all keys converted to symbols, as long as
+      # they respond to +to_sym+.
+      #
+      #   { 'name' => 'Rob', 'years' => '28' }.symbolize_keys
+      #   #=> { :name => "Rob", :years => "28" }
+      def self.symbolize_keys(hash)
+        symbolize_keys!(hash.dup)
       end
-      hash
+
+      # Destructively convert all keys to symbols, as long as they respond
+      # to +to_sym+. Same as +symbolize_keys+, but modifies +self+.
+      def self.symbolize_keys!(hash)
+        hash.keys.each do |key|
+          hash[(key.to_sym rescue key) || key] = hash.delete(key)
+        end
+        hash
+      end
     end
   end
 end

--- a/rb/lib/twitter-text/hit_highlighter.rb
+++ b/rb/lib/twitter-text/hit_highlighter.rb
@@ -1,86 +1,88 @@
 module Twitter
-  # Module for doing "hit highlighting" on tweets that have been auto-linked already.
-  # Useful with the results returned from the Search API.
-  module HitHighlighter extend self
-    # Default Tag used for hit highlighting
-    DEFAULT_HIGHLIGHT_TAG = "em"
+  module TwitterText
+    # Module for doing "hit highlighting" on tweets that have been auto-linked already.
+    # Useful with the results returned from the Search API.
+    module HitHighlighter extend self
+      # Default Tag used for hit highlighting
+      DEFAULT_HIGHLIGHT_TAG = "em"
 
-    # Add <tt><em></em></tt> tags around the <tt>hits</tt> provided in the <tt>text</tt>. The
-    # <tt>hits</tt> should be an array of (start, end) index pairs, relative to the original
-    # text, before auto-linking (but the <tt>text</tt> may already be auto-linked if desired)
-    #
-    # The <tt><em></em></tt> tags can be overridden using the <tt>:tag</tt> option. For example:
-    #
-    #  irb> hit_highlight("test hit here", [[5, 8]], :tag => 'strong')
-    #  => "test <strong>hit</strong> here"
-    def hit_highlight(text, hits = [], options = {})
-      if hits.empty?
-        return text
-      end
+      # Add <tt><em></em></tt> tags around the <tt>hits</tt> provided in the <tt>text</tt>. The
+      # <tt>hits</tt> should be an array of (start, end) index pairs, relative to the original
+      # text, before auto-linking (but the <tt>text</tt> may already be auto-linked if desired)
+      #
+      # The <tt><em></em></tt> tags can be overridden using the <tt>:tag</tt> option. For example:
+      #
+      #  irb> hit_highlight("test hit here", [[5, 8]], :tag => 'strong')
+      #  => "test <strong>hit</strong> here"
+      def hit_highlight(text, hits = [], options = {})
+        if hits.empty?
+          return text
+        end
 
-      tag_name = options[:tag] || DEFAULT_HIGHLIGHT_TAG
-      tags = ["<" + tag_name + ">", "</" + tag_name + ">"]
+        tag_name = options[:tag] || DEFAULT_HIGHLIGHT_TAG
+        tags = ["<" + tag_name + ">", "</" + tag_name + ">"]
 
-      chunks = text.split(/[<>]/)
+        chunks = text.split(/[<>]/)
 
-      result = []
-      chunk_index, chunk = 0, chunks[0]
-      chunk_chars = chunk.to_s.to_char_a
-      prev_chunks_len = 0
-      chunk_cursor = 0
-      start_in_chunk = false
-      for hit, index in hits.flatten.each_with_index do
-        tag = tags[index % 2]
+        result = []
+        chunk_index, chunk = 0, chunks[0]
+        chunk_chars = chunk.to_s.to_char_a
+        prev_chunks_len = 0
+        chunk_cursor = 0
+        start_in_chunk = false
+        for hit, index in hits.flatten.each_with_index do
+          tag = tags[index % 2]
 
-        placed = false
-        until chunk.nil? || hit < prev_chunks_len + chunk.length do
-          result << chunk_chars[chunk_cursor..-1]
-          if start_in_chunk && hit == prev_chunks_len + chunk_chars.length
-            result << tag
+          placed = false
+          until chunk.nil? || hit < prev_chunks_len + chunk.length do
+            result << chunk_chars[chunk_cursor..-1]
+            if start_in_chunk && hit == prev_chunks_len + chunk_chars.length
+              result << tag
+              placed = true
+            end
+
+            # correctly handle highlights that end on the final character.
+            if tag_text = chunks[chunk_index+1]
+              result << "<#{tag_text}>"
+            end
+
+            prev_chunks_len += chunk_chars.length
+            chunk_cursor = 0
+            chunk_index += 2
+            chunk = chunks[chunk_index]
+            chunk_chars = chunk.to_s.to_char_a
+            start_in_chunk = false
+          end
+
+          if !placed && !chunk.nil?
+            hit_spot = hit - prev_chunks_len
+            result << chunk_chars[chunk_cursor...hit_spot] << tag
+            chunk_cursor = hit_spot
+            if index % 2 == 0
+              start_in_chunk = true
+            else
+              start_in_chunk = false
+            end
             placed = true
           end
 
-          # correctly handle highlights that end on the final character.
-          if tag_text = chunks[chunk_index+1]
-            result << "<#{tag_text}>"
+          # ultimate fallback, hits that run off the end get a closing tag
+          if !placed
+            result << tag
           end
-
-          prev_chunks_len += chunk_chars.length
-          chunk_cursor = 0
-          chunk_index += 2
-          chunk = chunks[chunk_index]
-          chunk_chars = chunk.to_s.to_char_a
-          start_in_chunk = false
         end
 
-        if !placed && !chunk.nil?
-          hit_spot = hit - prev_chunks_len
-          result << chunk_chars[chunk_cursor...hit_spot] << tag
-          chunk_cursor = hit_spot
-          if index % 2 == 0
-            start_in_chunk = true
-          else
-            start_in_chunk = false
+        if chunk
+          if chunk_cursor < chunk_chars.length
+            result << chunk_chars[chunk_cursor..-1]
           end
-          placed = true
+          (chunk_index+1).upto(chunks.length-1).each do |i|
+            result << (i.even? ? chunks[i] : "<#{chunks[i]}>")
+          end
         end
 
-        # ultimate fallback, hits that run off the end get a closing tag
-        if !placed
-          result << tag
-        end
+        result.flatten.join
       end
-
-      if chunk
-        if chunk_cursor < chunk_chars.length
-          result << chunk_chars[chunk_cursor..-1]
-        end
-        (chunk_index+1).upto(chunks.length-1).each do |i|
-          result << (i.even? ? chunks[i] : "<#{chunks[i]}>")
-        end
-      end
-
-      result.flatten.join
     end
   end
 end

--- a/rb/lib/twitter-text/regex.rb
+++ b/rb/lib/twitter-text/regex.rb
@@ -1,249 +1,250 @@
 # encoding: utf-8
 
 module Twitter
-  # A collection of regular expressions for parsing Tweet text. The regular expression
-  # list is frozen at load time to ensure immutability. These regular expressions are
-  # used throughout the <tt>Twitter</tt> classes. Special care has been taken to make
-  # sure these reular expressions work with Tweets in all languages.
-  class Regex
-    require 'yaml'
+  module TwitterText
+    # A collection of regular expressions for parsing Tweet text. The regular expression
+    # list is frozen at load time to ensure immutability. These regular expressions are
+    # used throughout the <tt>TwitterText</tt> classes. Special care has been taken to make
+    # sure these reular expressions work with Tweets in all languages.
+    class Regex
+      require 'yaml'
 
-    REGEXEN = {} # :nodoc:
+      REGEXEN = {} # :nodoc:
 
-    def self.regex_range(from, to = nil) # :nodoc:
-      if $RUBY_1_9
-        if to
-          "\\u{#{from.to_s(16).rjust(4, '0')}}-\\u{#{to.to_s(16).rjust(4, '0')}}"
+      def self.regex_range(from, to = nil) # :nodoc:
+        if $RUBY_1_9
+          if to
+            "\\u{#{from.to_s(16).rjust(4, '0')}}-\\u{#{to.to_s(16).rjust(4, '0')}}"
+          else
+            "\\u{#{from.to_s(16).rjust(4, '0')}}"
+          end
         else
-          "\\u{#{from.to_s(16).rjust(4, '0')}}"
-        end
-      else
-        if to
-          [from].pack('U') + '-' + [to].pack('U')
-        else
-          [from].pack('U')
+          if to
+            [from].pack('U') + '-' + [to].pack('U')
+          else
+            [from].pack('U')
+          end
         end
       end
-    end
 
-    TLDS = YAML.load_file(
-      File.join(
-        File.expand_path('../../..', __FILE__), # project root
-        'lib', 'assets', 'tld_lib.yml'
-      )
-    )
-
-    # Space is more than %20, U+3000 for example is the full-width space used with Kanji. Provide a short-hand
-    # to access both the list of characters and a pattern suitible for use with String#split
-    #  Taken from: ActiveSupport::Multibyte::Handlers::UTF8Handler::UNICODE_WHITESPACE
-    UNICODE_SPACES = [
-          (0x0009..0x000D).to_a,  # White_Space # Cc   [5] <control-0009>..<control-000D>
-          0x0020,          # White_Space # Zs       SPACE
-          0x0085,          # White_Space # Cc       <control-0085>
-          0x00A0,          # White_Space # Zs       NO-BREAK SPACE
-          0x1680,          # White_Space # Zs       OGHAM SPACE MARK
-          0x180E,          # White_Space # Zs       MONGOLIAN VOWEL SEPARATOR
-          (0x2000..0x200A).to_a, # White_Space # Zs  [11] EN QUAD..HAIR SPACE
-          0x2028,          # White_Space # Zl       LINE SEPARATOR
-          0x2029,          # White_Space # Zp       PARAGRAPH SEPARATOR
-          0x202F,          # White_Space # Zs       NARROW NO-BREAK SPACE
-          0x205F,          # White_Space # Zs       MEDIUM MATHEMATICAL SPACE
-          0x3000,          # White_Space # Zs       IDEOGRAPHIC SPACE
-    ].flatten.map{|c| [c].pack('U*')}.freeze
-    REGEXEN[:spaces] = /[#{UNICODE_SPACES.join('')}]/o
-
-    # Character not allowed in Tweets
-    INVALID_CHARACTERS = [
-      0xFFFE, 0xFEFF, # BOM
-      0xFFFF,         # Special
-      0x202A, 0x202B, 0x202C, 0x202D, 0x202E # Directional change
-    ].map{|cp| [cp].pack('U') }.freeze
-    REGEXEN[:invalid_control_characters] = /[#{INVALID_CHARACTERS.join('')}]/o
-
-    major, minor, _patch = RUBY_VERSION.split('.')
-    if major.to_i >= 2 || major.to_i == 1 && minor.to_i >= 9 || (defined?(RUBY_ENGINE) && ["jruby", "rbx"].include?(RUBY_ENGINE))
-      REGEXEN[:list_name] = /[a-z][a-z0-9_\-\u0080-\u00ff]{0,24}/i
-    else
-      # This line barfs at compile time in Ruby 1.9, JRuby, or Rubinius.
-      REGEXEN[:list_name] = eval("/[a-z][a-z0-9_\\-\x80-\xff]{0,24}/i")
-    end
-
-    # Latin accented characters
-    # Excludes 0xd7 from the range (the multiplication sign, confusable with "x").
-    # Also excludes 0xf7, the division sign
-    LATIN_ACCENTS = [
-          regex_range(0xc0, 0xd6),
-          regex_range(0xd8, 0xf6),
-          regex_range(0xf8, 0xff),
-          regex_range(0x0100, 0x024f),
-          regex_range(0x0253, 0x0254),
-          regex_range(0x0256, 0x0257),
-          regex_range(0x0259),
-          regex_range(0x025b),
-          regex_range(0x0263),
-          regex_range(0x0268),
-          regex_range(0x026f),
-          regex_range(0x0272),
-          regex_range(0x0289),
-          regex_range(0x028b),
-          regex_range(0x02bb),
-          regex_range(0x0300, 0x036f),
-          regex_range(0x1e00, 0x1eff)
-    ].join('').freeze
-    REGEXEN[:latin_accents] = /[#{LATIN_ACCENTS}]+/o
-
-    RTL_CHARACTERS = [
-      regex_range(0x0600,0x06FF),
-      regex_range(0x0750,0x077F),
-      regex_range(0x0590,0x05FF),
-      regex_range(0xFE70,0xFEFF)
-    ].join('').freeze
-
-    PUNCTUATION_CHARS = '!"#$%&\'()*+,-./:;<=>?@\[\]^_\`{|}~'
-    SPACE_CHARS = " \t\n\x0B\f\r"
-    CTRL_CHARS = "\x00-\x1F\x7F"
-
-    # Generated from unicode_regex/unicode_regex_groups.scala, more inclusive than Ruby's \p{L}\p{M}
-    HASHTAG_LETTERS_AND_MARKS = "\\p{L}\\p{M}" +
-      "\u037f\u0528-\u052f\u08a0-\u08b2\u08e4-\u08ff\u0978\u0980\u0c00\u0c34\u0c81\u0d01\u0ede\u0edf" +
-      "\u10c7\u10cd\u10fd-\u10ff\u16f1-\u16f8\u17b4\u17b5\u191d\u191e\u1ab0-\u1abe\u1bab-\u1bad\u1bba-" +
-      "\u1bbf\u1cf3-\u1cf6\u1cf8\u1cf9\u1de7-\u1df5\u2cf2\u2cf3\u2d27\u2d2d\u2d66\u2d67\u9fcc\ua674-" +
-      "\ua67b\ua698-\ua69d\ua69f\ua792-\ua79f\ua7aa-\ua7ad\ua7b0\ua7b1\ua7f7-\ua7f9\ua9e0-\ua9ef\ua9fa-" +
-      "\ua9fe\uaa7c-\uaa7f\uaae0-\uaaef\uaaf2-\uaaf6\uab30-\uab5a\uab5c-\uab5f\uab64\uab65\uf870-\uf87f" +
-      "\uf882\uf884-\uf89f\uf8b8\uf8c1-\uf8d6\ufa2e\ufa2f\ufe27-\ufe2d\u{102e0}\u{1031f}\u{10350}-\u{1037a}" +
-      "\u{10500}-\u{10527}\u{10530}-\u{10563}\u{10600}-\u{10736}\u{10740}-\u{10755}\u{10760}-\u{10767}" +
-      "\u{10860}-\u{10876}\u{10880}-\u{1089e}\u{10980}-\u{109b7}\u{109be}\u{109bf}\u{10a80}-\u{10a9c}" +
-      "\u{10ac0}-\u{10ac7}\u{10ac9}-\u{10ae6}\u{10b80}-\u{10b91}\u{1107f}\u{110d0}-\u{110e8}\u{11100}-" +
-      "\u{11134}\u{11150}-\u{11173}\u{11176}\u{11180}-\u{111c4}\u{111da}\u{11200}-\u{11211}\u{11213}-" +
-      "\u{11237}\u{112b0}-\u{112ea}\u{11301}-\u{11303}\u{11305}-\u{1130c}\u{1130f}\u{11310}\u{11313}-" +
-      "\u{11328}\u{1132a}-\u{11330}\u{11332}\u{11333}\u{11335}-\u{11339}\u{1133c}-\u{11344}\u{11347}" +
-      "\u{11348}\u{1134b}-\u{1134d}\u{11357}\u{1135d}-\u{11363}\u{11366}-\u{1136c}\u{11370}-\u{11374}" +
-      "\u{11480}-\u{114c5}\u{114c7}\u{11580}-\u{115b5}\u{115b8}-\u{115c0}\u{11600}-\u{11640}\u{11644}" +
-      "\u{11680}-\u{116b7}\u{118a0}-\u{118df}\u{118ff}\u{11ac0}-\u{11af8}\u{1236f}-\u{12398}\u{16a40}-" +
-      "\u{16a5e}\u{16ad0}-\u{16aed}\u{16af0}-\u{16af4}\u{16b00}-\u{16b36}\u{16b40}-\u{16b43}\u{16b63}-" +
-      "\u{16b77}\u{16b7d}-\u{16b8f}\u{16f00}-\u{16f44}\u{16f50}-\u{16f7e}\u{16f8f}-\u{16f9f}\u{1bc00}-" +
-      "\u{1bc6a}\u{1bc70}-\u{1bc7c}\u{1bc80}-\u{1bc88}\u{1bc90}-\u{1bc99}\u{1bc9d}\u{1bc9e}\u{1e800}-" +
-      "\u{1e8c4}\u{1e8d0}-\u{1e8d6}\u{1ee00}-\u{1ee03}\u{1ee05}-\u{1ee1f}\u{1ee21}\u{1ee22}\u{1ee24}" +
-      "\u{1ee27}\u{1ee29}-\u{1ee32}\u{1ee34}-\u{1ee37}\u{1ee39}\u{1ee3b}\u{1ee42}\u{1ee47}\u{1ee49}" +
-      "\u{1ee4b}\u{1ee4d}-\u{1ee4f}\u{1ee51}\u{1ee52}\u{1ee54}\u{1ee57}\u{1ee59}\u{1ee5b}\u{1ee5d}\u{1ee5f}" +
-      "\u{1ee61}\u{1ee62}\u{1ee64}\u{1ee67}-\u{1ee6a}\u{1ee6c}-\u{1ee72}\u{1ee74}-\u{1ee77}\u{1ee79}-" +
-      "\u{1ee7c}\u{1ee7e}\u{1ee80}-\u{1ee89}\u{1ee8b}-\u{1ee9b}\u{1eea1}-\u{1eea3}\u{1eea5}-\u{1eea9}" +
-      "\u{1eeab}-\u{1eebb}"
-
-    # Generated from unicode_regex/unicode_regex_groups.scala, more inclusive than Ruby's \p{Nd}
-    HASHTAG_NUMERALS = "\\p{Nd}" +
-      "\u0de6-\u0def\ua9f0-\ua9f9\u{110f0}-\u{110f9}\u{11136}-\u{1113f}\u{111d0}-\u{111d9}\u{112f0}-" +
-      "\u{112f9}\u{114d0}-\u{114d9}\u{11650}-\u{11659}\u{116c0}-\u{116c9}\u{118e0}-\u{118e9}\u{16a60}-" +
-      "\u{16a69}\u{16b50}-\u{16b59}"
-
-    HASHTAG_SPECIAL_CHARS = "_\u200c\u200d\ua67e\u05be\u05f3\u05f4\uff5e\u301c\u309b\u309c\u30a0\u30fb\u3003\u0f0b\u0f0c\u00b7"
-
-    HASHTAG_LETTERS_NUMERALS = "#{HASHTAG_LETTERS_AND_MARKS}#{HASHTAG_NUMERALS}#{HASHTAG_SPECIAL_CHARS}"
-    HASHTAG_LETTERS_NUMERALS_SET = "[#{HASHTAG_LETTERS_NUMERALS}]"
-    HASHTAG_LETTERS_SET = "[#{HASHTAG_LETTERS_AND_MARKS}]"
-
-    HASHTAG = /(\A|\ufe0e|\ufe0f|[^&#{HASHTAG_LETTERS_NUMERALS}])(#|＃)(?!\ufe0f|\u20e3)(#{HASHTAG_LETTERS_NUMERALS_SET}*#{HASHTAG_LETTERS_SET}#{HASHTAG_LETTERS_NUMERALS_SET}*)/io
-
-    REGEXEN[:valid_hashtag] = /#{HASHTAG}/io
-    # Used in Extractor for final filtering
-    REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
-
-    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-z0-9_!#\$%&*@＠]|^|(?:^|[^a-z0-9_+~.-])[rR][tT]:?)/io
-    REGEXEN[:at_signs] = /[@＠]/
-    REGEXEN[:valid_mention_or_list] = /
-      (#{REGEXEN[:valid_mention_preceding_chars]})  # $1: Preceeding character
-      (#{REGEXEN[:at_signs]})                       # $2: At mark
-      ([a-z0-9_]{1,20})                             # $3: Screen name
-      (\/[a-z][a-zA-Z0-9_\-]{0,24})?                # $4: List (optional)
-    /iox
-    REGEXEN[:valid_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-z0-9_]{1,20})/io
-    # Used in Extractor for final filtering
-    REGEXEN[:end_mention_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/io
-
-    # URL related hash regex collection
-    REGEXEN[:valid_url_preceding_chars] = /(?:[^A-Z0-9@＠$#＃#{INVALID_CHARACTERS.join('')}]|^)/io
-    REGEXEN[:invalid_url_without_protocol_preceding_chars] = /[-_.\/]$/
-    DOMAIN_VALID_CHARS = "[^#{PUNCTUATION_CHARS}#{SPACE_CHARS}#{CTRL_CHARS}#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
-    REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
-    REGEXEN[:valid_domain_name] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
-
-    REGEXEN[:valid_gTLD] = %r{
-      (?:
-        (?:#{TLDS['generic'].join('|')})
-        (?=[^0-9a-z@]|$)
-      )
-    }ix
-
-    REGEXEN[:valid_ccTLD] = %r{
-      (?:
-        (?:#{TLDS['country'].join('|')})
-        (?=[^0-9a-z@]|$)
-      )
-    }ix
-    REGEXEN[:valid_punycode] = /(?:xn--[0-9a-z]+)/i
-
-    REGEXEN[:valid_special_cctld] = %r{
-      (?:
-        (?:co|tv)
-        (?=[^0-9a-z@]|$)
-      )
-    }ix
-
-    REGEXEN[:valid_domain] = /(?:
-      #{REGEXEN[:valid_subdomain]}*#{REGEXEN[:valid_domain_name]}
-      (?:#{REGEXEN[:valid_gTLD]}|#{REGEXEN[:valid_ccTLD]}|#{REGEXEN[:valid_punycode]})
-    )/iox
-
-    # This is used in Extractor
-    REGEXEN[:valid_ascii_domain] = /
-      (?:(?:[a-z0-9\-_]|#{REGEXEN[:latin_accents]})+\.)+
-      (?:#{REGEXEN[:valid_gTLD]}|#{REGEXEN[:valid_ccTLD]}|#{REGEXEN[:valid_punycode]})
-    /iox
-
-    # This is used in Extractor for stricter t.co URL extraction
-    REGEXEN[:valid_tco_url] = /^https?:\/\/t\.co\/([a-z0-9]+)/i
-
-    # This is used in Extractor to filter out unwanted URLs.
-    REGEXEN[:invalid_short_domain] = /\A#{REGEXEN[:valid_domain_name]}#{REGEXEN[:valid_ccTLD]}\Z/io
-    REGEXEN[:valid_special_short_domain] = /\A#{REGEXEN[:valid_domain_name]}#{REGEXEN[:valid_special_cctld]}\Z/io
-
-    REGEXEN[:valid_port_number] = /[0-9]+/
-
-    REGEXEN[:valid_general_url_path_chars] = /[a-z\p{Cyrillic}0-9!\*';:=\+\,\.\$\/%#\[\]\p{Pd}_~&\|@#{LATIN_ACCENTS}]/io
-    # Allow URL paths to contain up to two nested levels of balanced parens
-    #  1. Used in Wikipedia URLs like /Primer_(film)
-    #  2. Used in IIS sessions like /S(dfd346)/
-    #  3. Used in Rdio URLs like /track/We_Up_(Album_Version_(Edited))/
-    REGEXEN[:valid_url_balanced_parens] = /
-      \(
-        (?:
-          #{REGEXEN[:valid_general_url_path_chars]}+
-          |
-          # allow one nested level of balanced parentheses
-          (?:
-            #{REGEXEN[:valid_general_url_path_chars]}*
-            \(
-              #{REGEXEN[:valid_general_url_path_chars]}+
-            \)
-            #{REGEXEN[:valid_general_url_path_chars]}*
-          )
+      TLDS = YAML.load_file(
+        File.join(
+          File.expand_path('../../..', __FILE__), # project root
+          'lib', 'assets', 'tld_lib.yml'
         )
-      \)
-    /iox
-    # Valid end-of-path chracters (so /foo. does not gobble the period).
-    #   1. Allow =&# for empty URL parameters and other URL-join artifacts
-    REGEXEN[:valid_url_path_ending_chars] = /[a-z\p{Cyrillic}0-9=_#\/\+\-#{LATIN_ACCENTS}]|(?:#{REGEXEN[:valid_url_balanced_parens]})/io
-    REGEXEN[:valid_url_path] = /(?:
-      (?:
-        #{REGEXEN[:valid_general_url_path_chars]}*
-        (?:#{REGEXEN[:valid_url_balanced_parens]} #{REGEXEN[:valid_general_url_path_chars]}*)*
-        #{REGEXEN[:valid_url_path_ending_chars]}
-      )|(?:#{REGEXEN[:valid_general_url_path_chars]}+\/)
-    )/iox
+      )
 
-    REGEXEN[:valid_url_query_chars] = /[a-z0-9!?\*'\(\);:&=\+\$\/%#\[\]\-_\.,~|@]/i
-    REGEXEN[:valid_url_query_ending_chars] = /[a-z0-9_&=#\/\-]/i
-    REGEXEN[:valid_url] = %r{
+      # Space is more than %20, U+3000 for example is the full-width space used with Kanji. Provide a short-hand
+      # to access both the list of characters and a pattern suitible for use with String#split
+      #  Taken from: ActiveSupport::Multibyte::Handlers::UTF8Handler::UNICODE_WHITESPACE
+      UNICODE_SPACES = [
+        (0x0009..0x000D).to_a,  # White_Space # Cc   [5] <control-0009>..<control-000D>
+        0x0020,          # White_Space # Zs       SPACE
+        0x0085,          # White_Space # Cc       <control-0085>
+        0x00A0,          # White_Space # Zs       NO-BREAK SPACE
+        0x1680,          # White_Space # Zs       OGHAM SPACE MARK
+        0x180E,          # White_Space # Zs       MONGOLIAN VOWEL SEPARATOR
+        (0x2000..0x200A).to_a, # White_Space # Zs  [11] EN QUAD..HAIR SPACE
+        0x2028,          # White_Space # Zl       LINE SEPARATOR
+        0x2029,          # White_Space # Zp       PARAGRAPH SEPARATOR
+        0x202F,          # White_Space # Zs       NARROW NO-BREAK SPACE
+        0x205F,          # White_Space # Zs       MEDIUM MATHEMATICAL SPACE
+        0x3000,          # White_Space # Zs       IDEOGRAPHIC SPACE
+      ].flatten.map{|c| [c].pack('U*')}.freeze
+      REGEXEN[:spaces] = /[#{UNICODE_SPACES.join('')}]/o
+
+      # Character not allowed in Tweets
+      INVALID_CHARACTERS = [
+        0xFFFE, 0xFEFF, # BOM
+        0xFFFF,         # Special
+        0x202A, 0x202B, 0x202C, 0x202D, 0x202E # Directional change
+      ].map{|cp| [cp].pack('U') }.freeze
+      REGEXEN[:invalid_control_characters] = /[#{INVALID_CHARACTERS.join('')}]/o
+
+      major, minor, _patch = RUBY_VERSION.split('.')
+      if major.to_i >= 2 || major.to_i == 1 && minor.to_i >= 9 || (defined?(RUBY_ENGINE) && ["jruby", "rbx"].include?(RUBY_ENGINE))
+        REGEXEN[:list_name] = /[a-z][a-z0-9_\-\u0080-\u00ff]{0,24}/i
+      else
+        # This line barfs at compile time in Ruby 1.9, JRuby, or Rubinius.
+        REGEXEN[:list_name] = eval("/[a-z][a-z0-9_\\-\x80-\xff]{0,24}/i")
+      end
+
+      # Latin accented characters
+      # Excludes 0xd7 from the range (the multiplication sign, confusable with "x").
+      # Also excludes 0xf7, the division sign
+      LATIN_ACCENTS = [
+        regex_range(0xc0, 0xd6),
+        regex_range(0xd8, 0xf6),
+        regex_range(0xf8, 0xff),
+        regex_range(0x0100, 0x024f),
+        regex_range(0x0253, 0x0254),
+        regex_range(0x0256, 0x0257),
+        regex_range(0x0259),
+        regex_range(0x025b),
+        regex_range(0x0263),
+        regex_range(0x0268),
+        regex_range(0x026f),
+        regex_range(0x0272),
+        regex_range(0x0289),
+        regex_range(0x028b),
+        regex_range(0x02bb),
+        regex_range(0x0300, 0x036f),
+        regex_range(0x1e00, 0x1eff)
+      ].join('').freeze
+      REGEXEN[:latin_accents] = /[#{LATIN_ACCENTS}]+/o
+
+      RTL_CHARACTERS = [
+        regex_range(0x0600,0x06FF),
+        regex_range(0x0750,0x077F),
+        regex_range(0x0590,0x05FF),
+        regex_range(0xFE70,0xFEFF)
+      ].join('').freeze
+
+      PUNCTUATION_CHARS = '!"#$%&\'()*+,-./:;<=>?@\[\]^_\`{|}~'
+      SPACE_CHARS = " \t\n\x0B\f\r"
+      CTRL_CHARS = "\x00-\x1F\x7F"
+
+      # Generated from unicode_regex/unicode_regex_groups.scala, more inclusive than Ruby's \p{L}\p{M}
+      HASHTAG_LETTERS_AND_MARKS = "\\p{L}\\p{M}" +
+        "\u037f\u0528-\u052f\u08a0-\u08b2\u08e4-\u08ff\u0978\u0980\u0c00\u0c34\u0c81\u0d01\u0ede\u0edf" +
+        "\u10c7\u10cd\u10fd-\u10ff\u16f1-\u16f8\u17b4\u17b5\u191d\u191e\u1ab0-\u1abe\u1bab-\u1bad\u1bba-" +
+        "\u1bbf\u1cf3-\u1cf6\u1cf8\u1cf9\u1de7-\u1df5\u2cf2\u2cf3\u2d27\u2d2d\u2d66\u2d67\u9fcc\ua674-" +
+        "\ua67b\ua698-\ua69d\ua69f\ua792-\ua79f\ua7aa-\ua7ad\ua7b0\ua7b1\ua7f7-\ua7f9\ua9e0-\ua9ef\ua9fa-" +
+        "\ua9fe\uaa7c-\uaa7f\uaae0-\uaaef\uaaf2-\uaaf6\uab30-\uab5a\uab5c-\uab5f\uab64\uab65\uf870-\uf87f" +
+        "\uf882\uf884-\uf89f\uf8b8\uf8c1-\uf8d6\ufa2e\ufa2f\ufe27-\ufe2d\u{102e0}\u{1031f}\u{10350}-\u{1037a}" +
+        "\u{10500}-\u{10527}\u{10530}-\u{10563}\u{10600}-\u{10736}\u{10740}-\u{10755}\u{10760}-\u{10767}" +
+        "\u{10860}-\u{10876}\u{10880}-\u{1089e}\u{10980}-\u{109b7}\u{109be}\u{109bf}\u{10a80}-\u{10a9c}" +
+        "\u{10ac0}-\u{10ac7}\u{10ac9}-\u{10ae6}\u{10b80}-\u{10b91}\u{1107f}\u{110d0}-\u{110e8}\u{11100}-" +
+        "\u{11134}\u{11150}-\u{11173}\u{11176}\u{11180}-\u{111c4}\u{111da}\u{11200}-\u{11211}\u{11213}-" +
+        "\u{11237}\u{112b0}-\u{112ea}\u{11301}-\u{11303}\u{11305}-\u{1130c}\u{1130f}\u{11310}\u{11313}-" +
+        "\u{11328}\u{1132a}-\u{11330}\u{11332}\u{11333}\u{11335}-\u{11339}\u{1133c}-\u{11344}\u{11347}" +
+        "\u{11348}\u{1134b}-\u{1134d}\u{11357}\u{1135d}-\u{11363}\u{11366}-\u{1136c}\u{11370}-\u{11374}" +
+        "\u{11480}-\u{114c5}\u{114c7}\u{11580}-\u{115b5}\u{115b8}-\u{115c0}\u{11600}-\u{11640}\u{11644}" +
+        "\u{11680}-\u{116b7}\u{118a0}-\u{118df}\u{118ff}\u{11ac0}-\u{11af8}\u{1236f}-\u{12398}\u{16a40}-" +
+        "\u{16a5e}\u{16ad0}-\u{16aed}\u{16af0}-\u{16af4}\u{16b00}-\u{16b36}\u{16b40}-\u{16b43}\u{16b63}-" +
+        "\u{16b77}\u{16b7d}-\u{16b8f}\u{16f00}-\u{16f44}\u{16f50}-\u{16f7e}\u{16f8f}-\u{16f9f}\u{1bc00}-" +
+        "\u{1bc6a}\u{1bc70}-\u{1bc7c}\u{1bc80}-\u{1bc88}\u{1bc90}-\u{1bc99}\u{1bc9d}\u{1bc9e}\u{1e800}-" +
+        "\u{1e8c4}\u{1e8d0}-\u{1e8d6}\u{1ee00}-\u{1ee03}\u{1ee05}-\u{1ee1f}\u{1ee21}\u{1ee22}\u{1ee24}" +
+        "\u{1ee27}\u{1ee29}-\u{1ee32}\u{1ee34}-\u{1ee37}\u{1ee39}\u{1ee3b}\u{1ee42}\u{1ee47}\u{1ee49}" +
+        "\u{1ee4b}\u{1ee4d}-\u{1ee4f}\u{1ee51}\u{1ee52}\u{1ee54}\u{1ee57}\u{1ee59}\u{1ee5b}\u{1ee5d}\u{1ee5f}" +
+        "\u{1ee61}\u{1ee62}\u{1ee64}\u{1ee67}-\u{1ee6a}\u{1ee6c}-\u{1ee72}\u{1ee74}-\u{1ee77}\u{1ee79}-" +
+        "\u{1ee7c}\u{1ee7e}\u{1ee80}-\u{1ee89}\u{1ee8b}-\u{1ee9b}\u{1eea1}-\u{1eea3}\u{1eea5}-\u{1eea9}" +
+        "\u{1eeab}-\u{1eebb}"
+
+      # Generated from unicode_regex/unicode_regex_groups.scala, more inclusive than Ruby's \p{Nd}
+      HASHTAG_NUMERALS = "\\p{Nd}" +
+        "\u0de6-\u0def\ua9f0-\ua9f9\u{110f0}-\u{110f9}\u{11136}-\u{1113f}\u{111d0}-\u{111d9}\u{112f0}-" +
+        "\u{112f9}\u{114d0}-\u{114d9}\u{11650}-\u{11659}\u{116c0}-\u{116c9}\u{118e0}-\u{118e9}\u{16a60}-" +
+        "\u{16a69}\u{16b50}-\u{16b59}"
+
+      HASHTAG_SPECIAL_CHARS = "_\u200c\u200d\ua67e\u05be\u05f3\u05f4\uff5e\u301c\u309b\u309c\u30a0\u30fb\u3003\u0f0b\u0f0c\u00b7"
+
+      HASHTAG_LETTERS_NUMERALS = "#{HASHTAG_LETTERS_AND_MARKS}#{HASHTAG_NUMERALS}#{HASHTAG_SPECIAL_CHARS}"
+      HASHTAG_LETTERS_NUMERALS_SET = "[#{HASHTAG_LETTERS_NUMERALS}]"
+      HASHTAG_LETTERS_SET = "[#{HASHTAG_LETTERS_AND_MARKS}]"
+
+      HASHTAG = /(\A|\ufe0e|\ufe0f|[^&#{HASHTAG_LETTERS_NUMERALS}])(#|＃)(?!\ufe0f|\u20e3)(#{HASHTAG_LETTERS_NUMERALS_SET}*#{HASHTAG_LETTERS_SET}#{HASHTAG_LETTERS_NUMERALS_SET}*)/io
+
+      REGEXEN[:valid_hashtag] = /#{HASHTAG}/io
+      # Used in Extractor for final filtering
+      REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
+
+      REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-z0-9_!#\$%&*@＠]|^|(?:^|[^a-z0-9_+~.-])[rR][tT]:?)/io
+      REGEXEN[:at_signs] = /[@＠]/
+      REGEXEN[:valid_mention_or_list] = /
+        (#{REGEXEN[:valid_mention_preceding_chars]})  # $1: Preceeding character
+        (#{REGEXEN[:at_signs]})                       # $2: At mark
+        ([a-z0-9_]{1,20})                             # $3: Screen name
+        (\/[a-z][a-zA-Z0-9_\-]{0,24})?                # $4: List (optional)
+      /iox
+      REGEXEN[:valid_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-z0-9_]{1,20})/io
+      # Used in Extractor for final filtering
+      REGEXEN[:end_mention_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/io
+
+      # URL related hash regex collection
+      REGEXEN[:valid_url_preceding_chars] = /(?:[^A-Z0-9@＠$#＃#{INVALID_CHARACTERS.join('')}]|^)/io
+      REGEXEN[:invalid_url_without_protocol_preceding_chars] = /[-_.\/]$/
+      DOMAIN_VALID_CHARS = "[^#{PUNCTUATION_CHARS}#{SPACE_CHARS}#{CTRL_CHARS}#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
+      REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
+      REGEXEN[:valid_domain_name] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
+
+      REGEXEN[:valid_gTLD] = %r{
+        (?:
+          (?:#{TLDS['generic'].join('|')})
+          (?=[^0-9a-z@]|$)
+        )
+      }ix
+
+      REGEXEN[:valid_ccTLD] = %r{
+        (?:
+          (?:#{TLDS['country'].join('|')})
+          (?=[^0-9a-z@]|$)
+        )
+      }ix
+      REGEXEN[:valid_punycode] = /(?:xn--[0-9a-z]+)/i
+
+      REGEXEN[:valid_special_cctld] = %r{
+        (?:
+          (?:co|tv)
+          (?=[^0-9a-z@]|$)
+        )
+      }ix
+
+      REGEXEN[:valid_domain] = /(?:
+        #{REGEXEN[:valid_subdomain]}*#{REGEXEN[:valid_domain_name]}
+        (?:#{REGEXEN[:valid_gTLD]}|#{REGEXEN[:valid_ccTLD]}|#{REGEXEN[:valid_punycode]})
+      )/iox
+
+      # This is used in Extractor
+      REGEXEN[:valid_ascii_domain] = /
+        (?:(?:[a-z0-9\-_]|#{REGEXEN[:latin_accents]})+\.)+
+        (?:#{REGEXEN[:valid_gTLD]}|#{REGEXEN[:valid_ccTLD]}|#{REGEXEN[:valid_punycode]})
+      /iox
+
+      # This is used in Extractor for stricter t.co URL extraction
+      REGEXEN[:valid_tco_url] = /^https?:\/\/t\.co\/([a-z0-9]+)/i
+
+      # This is used in Extractor to filter out unwanted URLs.
+      REGEXEN[:invalid_short_domain] = /\A#{REGEXEN[:valid_domain_name]}#{REGEXEN[:valid_ccTLD]}\Z/io
+      REGEXEN[:valid_special_short_domain] = /\A#{REGEXEN[:valid_domain_name]}#{REGEXEN[:valid_special_cctld]}\Z/io
+
+      REGEXEN[:valid_port_number] = /[0-9]+/
+
+      REGEXEN[:valid_general_url_path_chars] = /[a-z\p{Cyrillic}0-9!\*';:=\+\,\.\$\/%#\[\]\p{Pd}_~&\|@#{LATIN_ACCENTS}]/io
+      # Allow URL paths to contain up to two nested levels of balanced parens
+      #  1. Used in Wikipedia URLs like /Primer_(film)
+      #  2. Used in IIS sessions like /S(dfd346)/
+      #  3. Used in Rdio URLs like /track/We_Up_(Album_Version_(Edited))/
+      REGEXEN[:valid_url_balanced_parens] = /
+        \(
+          (?:
+            #{REGEXEN[:valid_general_url_path_chars]}+
+            |
+            # allow one nested level of balanced parentheses
+            (?:
+              #{REGEXEN[:valid_general_url_path_chars]}*
+              \(
+                #{REGEXEN[:valid_general_url_path_chars]}+
+              \)
+              #{REGEXEN[:valid_general_url_path_chars]}*
+            )
+          )
+        \)
+      /iox
+      # Valid end-of-path chracters (so /foo. does not gobble the period).
+      #   1. Allow =&# for empty URL parameters and other URL-join artifacts
+      REGEXEN[:valid_url_path_ending_chars] = /[a-z\p{Cyrillic}0-9=_#\/\+\-#{LATIN_ACCENTS}]|(?:#{REGEXEN[:valid_url_balanced_parens]})/io
+      REGEXEN[:valid_url_path] = /(?:
+        (?:
+          #{REGEXEN[:valid_general_url_path_chars]}*
+          (?:#{REGEXEN[:valid_url_balanced_parens]} #{REGEXEN[:valid_general_url_path_chars]}*)*
+          #{REGEXEN[:valid_url_path_ending_chars]}
+        )|(?:#{REGEXEN[:valid_general_url_path_chars]}+\/)
+      )/iox
+
+      REGEXEN[:valid_url_query_chars] = /[a-z0-9!?\*'\(\);:&=\+\$\/%#\[\]\-_\.,~|@]/i
+      REGEXEN[:valid_url_query_ending_chars] = /[a-z0-9_&=#\/\-]/i
+      REGEXEN[:valid_url] = %r{
       (                                                                                     #   $1 total match
         (#{REGEXEN[:valid_url_preceding_chars]})                                            #   $2 Preceeding chracter
         (                                                                                   #   $3 URL
@@ -254,114 +255,115 @@ module Twitter
           (\?#{REGEXEN[:valid_url_query_chars]}*#{REGEXEN[:valid_url_query_ending_chars]})? #   $8 Query String
         )
       )
-    }iox
+      }iox
 
-    REGEXEN[:cashtag] = /[a-z]{1,6}(?:[._][a-z]{1,2})?/i
-    REGEXEN[:valid_cashtag] = /(^|#{REGEXEN[:spaces]})(\$)(#{REGEXEN[:cashtag]})(?=$|\s|[#{PUNCTUATION_CHARS}])/i
+      REGEXEN[:cashtag] = /[a-z]{1,6}(?:[._][a-z]{1,2})?/i
+      REGEXEN[:valid_cashtag] = /(^|#{REGEXEN[:spaces]})(\$)(#{REGEXEN[:cashtag]})(?=$|\s|[#{PUNCTUATION_CHARS}])/i
 
-    # These URL validation pattern strings are based on the ABNF from RFC 3986
-    REGEXEN[:validate_url_unreserved] = /[a-z\p{Cyrillic}0-9\p{Pd}._~]/i
-    REGEXEN[:validate_url_pct_encoded] = /(?:%[0-9a-f]{2})/i
-    REGEXEN[:validate_url_sub_delims] = /[!$&'()*+,;=]/i
-    REGEXEN[:validate_url_pchar] = /(?:
-      #{REGEXEN[:validate_url_unreserved]}|
-      #{REGEXEN[:validate_url_pct_encoded]}|
-      #{REGEXEN[:validate_url_sub_delims]}|
-      [:\|@]
-    )/iox
+      # These URL validation pattern strings are based on the ABNF from RFC 3986
+      REGEXEN[:validate_url_unreserved] = /[a-z\p{Cyrillic}0-9\p{Pd}._~]/i
+      REGEXEN[:validate_url_pct_encoded] = /(?:%[0-9a-f]{2})/i
+      REGEXEN[:validate_url_sub_delims] = /[!$&'()*+,;=]/i
+      REGEXEN[:validate_url_pchar] = /(?:
+        #{REGEXEN[:validate_url_unreserved]}|
+        #{REGEXEN[:validate_url_pct_encoded]}|
+        #{REGEXEN[:validate_url_sub_delims]}|
+        [:\|@]
+      )/iox
 
-    REGEXEN[:validate_url_scheme] = /(?:[a-z][a-z0-9+\-.]*)/i
-    REGEXEN[:validate_url_userinfo] = /(?:
-      #{REGEXEN[:validate_url_unreserved]}|
-      #{REGEXEN[:validate_url_pct_encoded]}|
-      #{REGEXEN[:validate_url_sub_delims]}|
-      :
-    )*/iox
+      REGEXEN[:validate_url_scheme] = /(?:[a-z][a-z0-9+\-.]*)/i
+      REGEXEN[:validate_url_userinfo] = /(?:
+        #{REGEXEN[:validate_url_unreserved]}|
+        #{REGEXEN[:validate_url_pct_encoded]}|
+        #{REGEXEN[:validate_url_sub_delims]}|
+        :
+      )*/iox
 
-    REGEXEN[:validate_url_dec_octet] = /(?:[0-9]|(?:[1-9][0-9])|(?:1[0-9]{2})|(?:2[0-4][0-9])|(?:25[0-5]))/i
-    REGEXEN[:validate_url_ipv4] =
-      /(?:#{REGEXEN[:validate_url_dec_octet]}(?:\.#{REGEXEN[:validate_url_dec_octet]}){3})/iox
+      REGEXEN[:validate_url_dec_octet] = /(?:[0-9]|(?:[1-9][0-9])|(?:1[0-9]{2})|(?:2[0-4][0-9])|(?:25[0-5]))/i
+      REGEXEN[:validate_url_ipv4] =
+        /(?:#{REGEXEN[:validate_url_dec_octet]}(?:\.#{REGEXEN[:validate_url_dec_octet]}){3})/iox
 
-    # Punting on real IPv6 validation for now
-    REGEXEN[:validate_url_ipv6] = /(?:\[[a-f0-9:\.]+\])/i
+      # Punting on real IPv6 validation for now
+      REGEXEN[:validate_url_ipv6] = /(?:\[[a-f0-9:\.]+\])/i
 
-    # Also punting on IPvFuture for now
-    REGEXEN[:validate_url_ip] = /(?:
-      #{REGEXEN[:validate_url_ipv4]}|
-      #{REGEXEN[:validate_url_ipv6]}
-    )/iox
+      # Also punting on IPvFuture for now
+      REGEXEN[:validate_url_ip] = /(?:
+        #{REGEXEN[:validate_url_ipv4]}|
+        #{REGEXEN[:validate_url_ipv6]}
+      )/iox
 
-    # This is more strict than the rfc specifies
-    REGEXEN[:validate_url_subdomain_segment] = /(?:[a-z0-9](?:[a-z0-9_\-]*[a-z0-9])?)/i
-    REGEXEN[:validate_url_domain_segment] = /(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?)/i
-    REGEXEN[:validate_url_domain_tld] = /(?:[a-z](?:[a-z0-9\-]*[a-z0-9])?)/i
-    REGEXEN[:validate_url_domain] = /(?:(?:#{REGEXEN[:validate_url_subdomain_segment]}\.)*
-                                     (?:#{REGEXEN[:validate_url_domain_segment]}\.)
-                                     #{REGEXEN[:validate_url_domain_tld]})/iox
+      # This is more strict than the rfc specifies
+      REGEXEN[:validate_url_subdomain_segment] = /(?:[a-z0-9](?:[a-z0-9_\-]*[a-z0-9])?)/i
+      REGEXEN[:validate_url_domain_segment] = /(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?)/i
+      REGEXEN[:validate_url_domain_tld] = /(?:[a-z](?:[a-z0-9\-]*[a-z0-9])?)/i
+      REGEXEN[:validate_url_domain] = /(?:(?:#{REGEXEN[:validate_url_subdomain_segment]}\.)*
+                                       (?:#{REGEXEN[:validate_url_domain_segment]}\.)
+                                       #{REGEXEN[:validate_url_domain_tld]})/iox
 
-    REGEXEN[:validate_url_host] = /(?:
-      #{REGEXEN[:validate_url_ip]}|
-      #{REGEXEN[:validate_url_domain]}
-    )/iox
+      REGEXEN[:validate_url_host] = /(?:
+        #{REGEXEN[:validate_url_ip]}|
+        #{REGEXEN[:validate_url_domain]}
+      )/iox
 
-    # Unencoded internationalized domains - this doesn't check for invalid UTF-8 sequences
-    REGEXEN[:validate_url_unicode_subdomain_segment] =
-      /(?:(?:[a-z0-9]|[^\x00-\x7f])(?:(?:[a-z0-9_\-]|[^\x00-\x7f])*(?:[a-z0-9]|[^\x00-\x7f]))?)/ix
-    REGEXEN[:validate_url_unicode_domain_segment] =
-      /(?:(?:[a-z0-9]|[^\x00-\x7f])(?:(?:[a-z0-9\-]|[^\x00-\x7f])*(?:[a-z0-9]|[^\x00-\x7f]))?)/ix
-    REGEXEN[:validate_url_unicode_domain_tld] =
-      /(?:(?:[a-z]|[^\x00-\x7f])(?:(?:[a-z0-9\-]|[^\x00-\x7f])*(?:[a-z0-9]|[^\x00-\x7f]))?)/ix
-    REGEXEN[:validate_url_unicode_domain] = /(?:(?:#{REGEXEN[:validate_url_unicode_subdomain_segment]}\.)*
-                                             (?:#{REGEXEN[:validate_url_unicode_domain_segment]}\.)
-                                             #{REGEXEN[:validate_url_unicode_domain_tld]})/iox
+      # Unencoded internationalized domains - this doesn't check for invalid UTF-8 sequences
+      REGEXEN[:validate_url_unicode_subdomain_segment] =
+        /(?:(?:[a-z0-9]|[^\x00-\x7f])(?:(?:[a-z0-9_\-]|[^\x00-\x7f])*(?:[a-z0-9]|[^\x00-\x7f]))?)/ix
+      REGEXEN[:validate_url_unicode_domain_segment] =
+        /(?:(?:[a-z0-9]|[^\x00-\x7f])(?:(?:[a-z0-9\-]|[^\x00-\x7f])*(?:[a-z0-9]|[^\x00-\x7f]))?)/ix
+      REGEXEN[:validate_url_unicode_domain_tld] =
+        /(?:(?:[a-z]|[^\x00-\x7f])(?:(?:[a-z0-9\-]|[^\x00-\x7f])*(?:[a-z0-9]|[^\x00-\x7f]))?)/ix
+      REGEXEN[:validate_url_unicode_domain] = /(?:(?:#{REGEXEN[:validate_url_unicode_subdomain_segment]}\.)*
+                                               (?:#{REGEXEN[:validate_url_unicode_domain_segment]}\.)
+                                               #{REGEXEN[:validate_url_unicode_domain_tld]})/iox
 
-    REGEXEN[:validate_url_unicode_host] = /(?:
-      #{REGEXEN[:validate_url_ip]}|
-      #{REGEXEN[:validate_url_unicode_domain]}
-    )/iox
+      REGEXEN[:validate_url_unicode_host] = /(?:
+        #{REGEXEN[:validate_url_ip]}|
+        #{REGEXEN[:validate_url_unicode_domain]}
+      )/iox
 
-    REGEXEN[:validate_url_port] = /[0-9]{1,5}/
+      REGEXEN[:validate_url_port] = /[0-9]{1,5}/
 
-    REGEXEN[:validate_url_unicode_authority] = %r{
-      (?:(#{REGEXEN[:validate_url_userinfo]})@)?     #  $1 userinfo
-      (#{REGEXEN[:validate_url_unicode_host]})       #  $2 host
-      (?::(#{REGEXEN[:validate_url_port]}))?         #  $3 port
-    }iox
+      REGEXEN[:validate_url_unicode_authority] = %r{
+        (?:(#{REGEXEN[:validate_url_userinfo]})@)?     #  $1 userinfo
+        (#{REGEXEN[:validate_url_unicode_host]})       #  $2 host
+        (?::(#{REGEXEN[:validate_url_port]}))?         #  $3 port
+      }iox
 
-    REGEXEN[:validate_url_authority] = %r{
-      (?:(#{REGEXEN[:validate_url_userinfo]})@)?     #  $1 userinfo
-      (#{REGEXEN[:validate_url_host]})               #  $2 host
-      (?::(#{REGEXEN[:validate_url_port]}))?         #  $3 port
-    }iox
+      REGEXEN[:validate_url_authority] = %r{
+        (?:(#{REGEXEN[:validate_url_userinfo]})@)?     #  $1 userinfo
+        (#{REGEXEN[:validate_url_host]})               #  $2 host
+        (?::(#{REGEXEN[:validate_url_port]}))?         #  $3 port
+      }iox
 
-    REGEXEN[:validate_url_path] = %r{(/#{REGEXEN[:validate_url_pchar]}*)*}i
-    REGEXEN[:validate_url_query] = %r{(#{REGEXEN[:validate_url_pchar]}|/|\?)*}i
-    REGEXEN[:validate_url_fragment] = %r{(#{REGEXEN[:validate_url_pchar]}|/|\?)*}i
+      REGEXEN[:validate_url_path] = %r{(/#{REGEXEN[:validate_url_pchar]}*)*}i
+      REGEXEN[:validate_url_query] = %r{(#{REGEXEN[:validate_url_pchar]}|/|\?)*}i
+      REGEXEN[:validate_url_fragment] = %r{(#{REGEXEN[:validate_url_pchar]}|/|\?)*}i
 
-    # Modified version of RFC 3986 Appendix B
-    REGEXEN[:validate_url_unencoded] = %r{
-      \A                                #  Full URL
-      (?:
-        ([^:/?#]+)://                  #  $1 Scheme
-      )?
-      ([^/?#]*)                        #  $2 Authority
-      ([^?#]*)                         #  $3 Path
-      (?:
-        \?([^#]*)                      #  $4 Query
-      )?
-      (?:
-        \#(.*)                         #  $5 Fragment
-      )?\Z
-    }ix
+      # Modified version of RFC 3986 Appendix B
+      REGEXEN[:validate_url_unencoded] = %r{
+        \A                                #  Full URL
+        (?:
+          ([^:/?#]+)://                  #  $1 Scheme
+        )?
+        ([^/?#]*)                        #  $2 Authority
+        ([^?#]*)                         #  $3 Path
+        (?:
+          \?([^#]*)                      #  $4 Query
+        )?
+        (?:
+          \#(.*)                         #  $5 Fragment
+        )?\Z
+      }ix
 
-    REGEXEN[:rtl_chars] = /[#{RTL_CHARACTERS}]/io
+      REGEXEN[:rtl_chars] = /[#{RTL_CHARACTERS}]/io
 
-    REGEXEN.each_pair{|k,v| v.freeze }
+      REGEXEN.each_pair{|k,v| v.freeze }
 
-    # Return the regular expression for a given <tt>key</tt>. If the <tt>key</tt>
-    # is not a known symbol a <tt>nil</tt> will be returned.
-    def self.[](key)
-      REGEXEN[key]
+      # Return the regular expression for a given <tt>key</tt>. If the <tt>key</tt>
+      # is not a known symbol a <tt>nil</tt> will be returned.
+      def self.[](key)
+        REGEXEN[key]
+      end
     end
   end
 end

--- a/rb/lib/twitter-text/rewriter.rb
+++ b/rb/lib/twitter-text/rewriter.rb
@@ -1,63 +1,65 @@
 module Twitter
-  # A module provides base methods to rewrite usernames, lists, hashtags and URLs.
-  module Rewriter extend self
-    def rewrite_entities(text, entities)
-      chars = text.to_s.to_char_a
+  module TwitterText
+    # A module provides base methods to rewrite usernames, lists, hashtags and URLs.
+    module Rewriter extend self
+      def rewrite_entities(text, entities)
+        chars = text.to_s.to_char_a
 
-      # sort by start index
-      entities = entities.sort_by do |entity|
-        indices = entity.respond_to?(:indices) ? entity.indices : entity[:indices]
-        indices.first
+        # sort by start index
+        entities = entities.sort_by do |entity|
+          indices = entity.respond_to?(:indices) ? entity.indices : entity[:indices]
+          indices.first
+        end
+
+        result = []
+        last_index = entities.inject(0) do |index, entity|
+          indices = entity.respond_to?(:indices) ? entity.indices : entity[:indices]
+          result << chars[index...indices.first]
+          result << yield(entity, chars)
+          indices.last
+        end
+        result << chars[last_index..-1]
+
+        result.flatten.join
       end
 
-      result = []
-      last_index = entities.inject(0) do |index, entity|
-        indices = entity.respond_to?(:indices) ? entity.indices : entity[:indices]
-        result << chars[index...indices.first]
-        result << yield(entity, chars)
-        indices.last
-      end
-      result << chars[last_index..-1]
+      # These methods are deprecated, will be removed in future.
+      extend Deprecation
 
-      result.flatten.join
+      def rewrite(text, options = {})
+        [:hashtags, :urls, :usernames_or_lists].inject(text) do |key|
+          options[key] ? send(:"rewrite_#{key}", text, &options[key]) : text
+        end
+      end
+      deprecate :rewrite, :rewrite_entities
+
+      def rewrite_usernames_or_lists(text)
+        entities = Extractor.extract_mentions_or_lists_with_indices(text)
+        rewrite_entities(text, entities) do |entity, chars|
+          at = chars[entity[:indices].first]
+          list_slug = entity[:list_slug]
+          list_slug = nil if list_slug.empty?
+          yield(at, entity[:screen_name], list_slug)
+        end
+      end
+      deprecate :rewrite_usernames_or_lists, :rewrite_entities
+
+      def rewrite_hashtags(text)
+        entities = Extractor.extract_hashtags_with_indices(text)
+        rewrite_entities(text, entities) do |entity, chars|
+          hash = chars[entity[:indices].first]
+          yield(hash, entity[:hashtag])
+        end
+      end
+      deprecate :rewrite_hashtags, :rewrite_entities
+
+      def rewrite_urls(text)
+        entities = Extractor.extract_urls_with_indices(text, :extract_url_without_protocol => false)
+        rewrite_entities(text, entities) do |entity, chars|
+          yield(entity[:url])
+        end
+      end
+      deprecate :rewrite_urls, :rewrite_entities
     end
-
-    # These methods are deprecated, will be removed in future.
-    extend Deprecation
-
-    def rewrite(text, options = {})
-      [:hashtags, :urls, :usernames_or_lists].inject(text) do |key|
-        options[key] ? send(:"rewrite_#{key}", text, &options[key]) : text
-      end
-    end
-    deprecate :rewrite, :rewrite_entities
-
-    def rewrite_usernames_or_lists(text)
-      entities = Extractor.extract_mentions_or_lists_with_indices(text)
-      rewrite_entities(text, entities) do |entity, chars|
-        at = chars[entity[:indices].first]
-        list_slug = entity[:list_slug]
-        list_slug = nil if list_slug.empty?
-        yield(at, entity[:screen_name], list_slug)
-      end
-    end
-    deprecate :rewrite_usernames_or_lists, :rewrite_entities
-
-    def rewrite_hashtags(text)
-      entities = Extractor.extract_hashtags_with_indices(text)
-      rewrite_entities(text, entities) do |entity, chars|
-        hash = chars[entity[:indices].first]
-        yield(hash, entity[:hashtag])
-      end
-    end
-    deprecate :rewrite_hashtags, :rewrite_entities
-
-    def rewrite_urls(text)
-      entities = Extractor.extract_urls_with_indices(text, :extract_url_without_protocol => false)
-      rewrite_entities(text, entities) do |entity, chars|
-        yield(entity[:url])
-      end
-    end
-    deprecate :rewrite_urls, :rewrite_entities
   end
 end

--- a/rb/lib/twitter-text/unicode.rb
+++ b/rb/lib/twitter-text/unicode.rb
@@ -1,26 +1,27 @@
 module Twitter
-  # This module lazily defines constants of the form Uxxxx for all Unicode
-  # codepoints from U0000 to U10FFFF. The value of each constant is the
-  # UTF-8 string for the codepoint.
-  # Examples:
-  #   copyright = Unicode::U00A9
-  #   euro = Unicode::U20AC
-  #   infinity = Unicode::U221E
-  #
-  module Unicode
-    CODEPOINT_REGEX = /^U_?([0-9a-fA-F]{4,5}|10[0-9a-fA-F]{4})$/
+  module TwitterText
+    # This module lazily defines constants of the form Uxxxx for all Unicode
+    # codepoints from U0000 to U10FFFF. The value of each constant is the
+    # UTF-8 string for the codepoint.
+    # Examples:
+    #   copyright = Unicode::U00A9
+    #   euro = Unicode::U20AC
+    #   infinity = Unicode::U221E
+    #
+    module Unicode
+      CODEPOINT_REGEX = /^U_?([0-9a-fA-F]{4,5}|10[0-9a-fA-F]{4})$/
 
-    def self.const_missing(name)
-      # Check that the constant name is of the right form: U0000 to U10FFFF
-      if name.to_s =~ CODEPOINT_REGEX
-        # Convert the codepoint to an immutable UTF-8 string,
-        # define a real constant for that value and return the value
-        #p name, name.class
-        const_set(name, [$1.to_i(16)].pack("U").freeze)
-      else  # Raise an error for constants that are not Unicode.
-        raise NameError, "Uninitialized constant: Unicode::#{name}"
+      def self.const_missing(name)
+        # Check that the constant name is of the right form: U0000 to U10FFFF
+        if name.to_s =~ CODEPOINT_REGEX
+          # Convert the codepoint to an immutable UTF-8 string,
+          # define a real constant for that value and return the value
+          #p name, name.class
+          const_set(name, [$1.to_i(16)].pack("U").freeze)
+        else  # Raise an error for constants that are not Unicode.
+          raise NameError, "Uninitialized constant: Unicode::#{name}"
+        end
       end
     end
   end
-
 end

--- a/rb/lib/twitter-text/validation.rb
+++ b/rb/lib/twitter-text/validation.rb
@@ -1,225 +1,227 @@
 require 'unf'
 
 module Twitter
-  module Validation extend self
-    DEFAULT_TCO_URL_LENGTHS = {
-      :short_url_length => 23,
-    }
+  module TwitterText
+    module Validation extend self
+      DEFAULT_TCO_URL_LENGTHS = {
+        :short_url_length => 23,
+      }
 
-    # :weighted_length the weighted length of tweet based on weights specified in the config
-    # :valid If tweet is valid
-    # :permillage permillage of the tweet over the max length specified in config
-    # :valid_range_start beginning of valid text
-    # :valid_range_end End index of valid part of the tweet text (inclusive)
-    # :display_range_start beginning index of display text
-    # :display_range_end end index of display text (inclusive)
-    class ParseResults < Hash
+      # :weighted_length the weighted length of tweet based on weights specified in the config
+      # :valid If tweet is valid
+      # :permillage permillage of the tweet over the max length specified in config
+      # :valid_range_start beginning of valid text
+      # :valid_range_end End index of valid part of the tweet text (inclusive)
+      # :display_range_start beginning index of display text
+      # :display_range_end end index of display text (inclusive)
+      class ParseResults < Hash
 
-      RESULT_PARAMS = [:weighted_length, :valid, :permillage, :valid_range_start, :valid_range_end, :display_range_start, :display_range_end]
+        RESULT_PARAMS = [:weighted_length, :valid, :permillage, :valid_range_start, :valid_range_end, :display_range_start, :display_range_end]
 
-      def self.empty
-        return ParseResults.new(weighted_length: 0, permillage: 0, valid: true, display_range_start: 0, display_range_end: 0, valid_range_start: 0, valid_range_end: 0)
-      end
-
-      def initialize(params = {})
-        RESULT_PARAMS.each do |key|
-          super[key] = params[key] if params.key?(key)
+        def self.empty
+          return ParseResults.new(weighted_length: 0, permillage: 0, valid: true, display_range_start: 0, display_range_end: 0, valid_range_start: 0, valid_range_end: 0)
         end
-      end
-    end
 
-    # Parse input text and return hash with descriptive parameters populated.
-    def parse_tweet(text, options = {})
-      options = DEFAULT_TCO_URL_LENGTHS.merge(options)
-      config = options[:config] || Twitter::Configuration.default_configuration
-      normalized_text = text.to_nfc
-      normalized_text_length = normalized_text.char_length
-      unless (normalized_text_length > 0)
-        ParseResults.empty()
-      end
-
-      scale = config.scale
-      max_weighted_tweet_length = config.max_weighted_tweet_length
-      scaled_max_weighted_tweet_length = max_weighted_tweet_length * scale
-      transformed_url_length = config.transformed_url_length * scale
-      ranges = config.ranges
-
-      url_entities = Twitter::Extractor.extract_urls_with_indices(normalized_text)
-
-      has_invalid_chars = false
-      weighted_count = 0
-      offset = 0
-      display_offset = 0
-      valid_offset = 0
-
-      while offset < normalized_text_length
-        # Reset the default char weight each pass through the loop
-        char_weight = config.default_weight
-        url_entities.each do |url_entity|
-          if url_entity[:indices].first == offset
-            url_length = url_entity[:indices].last - url_entity[:indices].first
-            weighted_count += transformed_url_length
-            offset += url_length
-            display_offset += url_length
-            if weighted_count <= scaled_max_weighted_tweet_length
-              valid_offset += url_length
-            end
-            # Finding a match breaks the loop; order of ranges matters.
-            break
+        def initialize(params = {})
+          RESULT_PARAMS.each do |key|
+            super[key] = params[key] if params.key?(key)
           end
         end
+      end
 
-        if offset < normalized_text_length
-          code_point = normalized_text[offset]
+      # Parse input text and return hash with descriptive parameters populated.
+      def parse_tweet(text, options = {})
+        options = DEFAULT_TCO_URL_LENGTHS.merge(options)
+        config = options[:config] || Twitter::TwitterText::Configuration.default_configuration
+        normalized_text = text.to_nfc
+        normalized_text_length = normalized_text.char_length
+        unless (normalized_text_length > 0)
+          ParseResults.empty()
+        end
 
-          ranges.each do |range|
-            if range.contains?(code_point.unpack("U").first)
-              char_weight = range.weight
+        scale = config.scale
+        max_weighted_tweet_length = config.max_weighted_tweet_length
+        scaled_max_weighted_tweet_length = max_weighted_tweet_length * scale
+        transformed_url_length = config.transformed_url_length * scale
+        ranges = config.ranges
+
+        url_entities = Twitter::TwitterText::Extractor.extract_urls_with_indices(normalized_text)
+
+        has_invalid_chars = false
+        weighted_count = 0
+        offset = 0
+        display_offset = 0
+        valid_offset = 0
+
+        while offset < normalized_text_length
+          # Reset the default char weight each pass through the loop
+          char_weight = config.default_weight
+          url_entities.each do |url_entity|
+            if url_entity[:indices].first == offset
+              url_length = url_entity[:indices].last - url_entity[:indices].first
+              weighted_count += transformed_url_length
+              offset += url_length
+              display_offset += url_length
+              if weighted_count <= scaled_max_weighted_tweet_length
+                valid_offset += url_length
+              end
+              # Finding a match breaks the loop; order of ranges matters.
               break
             end
           end
 
-          weighted_count += char_weight
+          if offset < normalized_text_length
+            code_point = normalized_text[offset]
 
-          has_invalid_chars = contains_invalid?(normalized_text[offset]) unless has_invalid_chars
-          char_count = code_point.char_length
-          offset += char_count
-          display_offset += char_count
+            ranges.each do |range|
+              if range.contains?(code_point.unpack("U").first)
+                char_weight = range.weight
+                break
+              end
+            end
 
-          if !has_invalid_chars && (weighted_count <= scaled_max_weighted_tweet_length)
-            valid_offset += char_count
+            weighted_count += char_weight
+
+            has_invalid_chars = contains_invalid?(normalized_text[offset]) unless has_invalid_chars
+            char_count = code_point.char_length
+            offset += char_count
+            display_offset += char_count
+
+            if !has_invalid_chars && (weighted_count <= scaled_max_weighted_tweet_length)
+              valid_offset += char_count
+            end
           end
         end
-      end
-      normalized_text_offset = text.char_length - normalized_text.char_length
-      scaled_weighted_length = weighted_count / scale
-      is_valid = !has_invalid_chars && (scaled_weighted_length <= max_weighted_tweet_length)
-      permillage = scaled_weighted_length * 1000 / max_weighted_tweet_length
+        normalized_text_offset = text.char_length - normalized_text.char_length
+        scaled_weighted_length = weighted_count / scale
+        is_valid = !has_invalid_chars && (scaled_weighted_length <= max_weighted_tweet_length)
+        permillage = scaled_weighted_length * 1000 / max_weighted_tweet_length
 
-      return ParseResults.new(weighted_length: scaled_weighted_length, permillage: permillage, valid: is_valid, display_range_start: 0, display_range_end: (display_offset + normalized_text_offset - 1), valid_range_start: 0, valid_range_end: (valid_offset + normalized_text_offset - 1))
-    end
-
-    def contains_invalid?(text)
-      return false if !text || text.empty?
-      begin
-        return true if Twitter::Regex::INVALID_CHARACTERS.any?{|invalid_char| text.include?(invalid_char) }
-      rescue ArgumentError
-        # non-Unicode value.
-        return true
-      end
-      return false
-    end
-
-    def valid_username?(username)
-      return false if !username || username.empty?
-
-      extracted = Twitter::Extractor.extract_mentioned_screen_names(username)
-      # Should extract the username minus the @ sign, hence the [1..-1]
-      extracted.size == 1 && extracted.first == username[1..-1]
-    end
-
-    VALID_LIST_RE = /\A#{Twitter::Regex[:valid_mention_or_list]}\z/o
-    def valid_list?(username_list)
-      match = username_list.match(VALID_LIST_RE)
-      # Must have matched and had nothing before or after
-      !!(match && match[1] == "" && match[4] && !match[4].empty?)
-    end
-
-    def valid_hashtag?(hashtag)
-      return false if !hashtag || hashtag.empty?
-
-      extracted = Twitter::Extractor.extract_hashtags(hashtag)
-      # Should extract the hashtag minus the # sign, hence the [1..-1]
-      extracted.size == 1 && extracted.first == hashtag[1..-1]
-    end
-
-    def valid_url?(url, unicode_domains=true, require_protocol=true)
-      return false if !url || url.empty?
-
-      url_parts = url.match(Twitter::Regex[:validate_url_unencoded])
-      return false unless (url_parts && url_parts.to_s == url)
-
-      scheme, authority, path, query, fragment = url_parts.captures
-
-      return false unless ((!require_protocol ||
-                           (valid_match?(scheme, Twitter::Regex[:validate_url_scheme]) && scheme.match(/\Ahttps?\Z/i))) &&
-                           valid_match?(path, Twitter::Regex[:validate_url_path]) &&
-                           valid_match?(query, Twitter::Regex[:validate_url_query], true) &&
-                           valid_match?(fragment, Twitter::Regex[:validate_url_fragment], true))
-
-      return (unicode_domains && valid_match?(authority, Twitter::Regex[:validate_url_unicode_authority])) ||
-             (!unicode_domains && valid_match?(authority, Twitter::Regex[:validate_url_authority]))
-    end
-
-    # These methods are deprecated, will be removed in future.
-    extend Deprecation
-
-    MAX_LENGTH_LEGACY = 140
-
-    # DEPRECATED: Please use parse_text instead.
-    #
-    # Returns the length of the string as it would be displayed. This is equivilent to the length of the Unicode NFC
-    # (See: http://www.unicode.org/reports/tr15). This is needed in order to consistently calculate the length of a
-    # string no matter which actual form was transmitted. For example:
-    #
-    #     U+0065  Latin Small Letter E
-    # +   U+0301  Combining Acute Accent
-    # ----------
-    # =   2 bytes, 2 characters, displayed as é (1 visual glyph)
-    #     … The NFC of {U+0065, U+0301} is {U+00E9}, which is a single chracter and a +display_length+ of 1
-    #
-    # The string could also contain U+00E9 already, in which case the canonicalization will not change the value.
-    #
-    def tweet_length(text, options = {})
-      options = DEFAULT_TCO_URL_LENGTHS.merge(options)
-
-      length = text.to_nfc.unpack("U*").length
-
-      Twitter::Extractor.extract_urls_with_indices(text) do |url, start_position, end_position|
-        length += start_position - end_position
-        length += options[:short_url_length] if url.length > 0
+        return ParseResults.new(weighted_length: scaled_weighted_length, permillage: permillage, valid: is_valid, display_range_start: 0, display_range_end: (display_offset + normalized_text_offset - 1), valid_range_start: 0, valid_range_end: (valid_offset + normalized_text_offset - 1))
       end
 
-      length
-    end
-    deprecate :tweet_length, :parse_tweet
-
-    # DEPRECATED: Please use parse_text instead.
-    #
-    # Check the <tt>text</tt> for any reason that it may not be valid as a Tweet. This is meant as a pre-validation
-    # before posting to api.twitter.com. There are several server-side reasons for Tweets to fail but this pre-validation
-    # will allow quicker feedback.
-    #
-    # Returns <tt>false</tt> if this <tt>text</tt> is valid. Otherwise one of the following Symbols will be returned:
-    #
-    #   <tt>:too_long</tt>:: if the <tt>text</tt> is too long
-    #   <tt>:empty</tt>:: if the <tt>text</tt> is nil or empty
-    #   <tt>:invalid_characters</tt>:: if the <tt>text</tt> contains non-Unicode or any of the disallowed Unicode characters
-    def tweet_invalid?(text)
-      return :empty if !text || text.empty?
-      begin
-        return :too_long if tweet_length(text) > MAX_LENGTH_LEGACY
-        return :invalid_characters if Twitter::Regex::INVALID_CHARACTERS.any?{|invalid_char| text.include?(invalid_char) }
-      rescue ArgumentError
-        # non-Unicode value.
-        return :invalid_characters
+      def contains_invalid?(text)
+        return false if !text || text.empty?
+        begin
+          return true if Twitter::TwitterText::Regex::INVALID_CHARACTERS.any?{|invalid_char| text.include?(invalid_char) }
+        rescue ArgumentError
+          # non-Unicode value.
+          return true
+        end
+        return false
       end
 
-      return false
-    end
-    deprecate :tweet_invalid?, :parse_tweet
+      def valid_username?(username)
+        return false if !username || username.empty?
 
-    def valid_tweet_text?(text)
-      !tweet_invalid?(text)
-    end
-    deprecate :valid_tweet_text?, :parse_tweet
+        extracted = Twitter::TwitterText::Extractor.extract_mentioned_screen_names(username)
+        # Should extract the username minus the @ sign, hence the [1..-1]
+        extracted.size == 1 && extracted.first == username[1..-1]
+      end
 
-    private
+      VALID_LIST_RE = /\A#{Twitter::TwitterText::Regex[:valid_mention_or_list]}\z/o
+      def valid_list?(username_list)
+        match = username_list.match(VALID_LIST_RE)
+        # Must have matched and had nothing before or after
+        !!(match && match[1] == "" && match[4] && !match[4].empty?)
+      end
 
-    def valid_match?(string, regex, optional=false)
-      return (string && string.match(regex) && $~.to_s == string) unless optional
+      def valid_hashtag?(hashtag)
+        return false if !hashtag || hashtag.empty?
 
-      !(string && (!string.match(regex) || $~.to_s != string))
+        extracted = Twitter::TwitterText::Extractor.extract_hashtags(hashtag)
+        # Should extract the hashtag minus the # sign, hence the [1..-1]
+        extracted.size == 1 && extracted.first == hashtag[1..-1]
+      end
+
+      def valid_url?(url, unicode_domains=true, require_protocol=true)
+        return false if !url || url.empty?
+
+        url_parts = url.match(Twitter::TwitterText::Regex[:validate_url_unencoded])
+        return false unless (url_parts && url_parts.to_s == url)
+
+        scheme, authority, path, query, fragment = url_parts.captures
+
+        return false unless ((!require_protocol ||
+                              (valid_match?(scheme, Twitter::TwitterText::Regex[:validate_url_scheme]) && scheme.match(/\Ahttps?\Z/i))) &&
+                             valid_match?(path, Twitter::TwitterText::Regex[:validate_url_path]) &&
+                             valid_match?(query, Twitter::TwitterText::Regex[:validate_url_query], true) &&
+                             valid_match?(fragment, Twitter::TwitterText::Regex[:validate_url_fragment], true))
+
+        return (unicode_domains && valid_match?(authority, Twitter::TwitterText::Regex[:validate_url_unicode_authority])) ||
+               (!unicode_domains && valid_match?(authority, Twitter::TwitterText::Regex[:validate_url_authority]))
+      end
+
+      # These methods are deprecated, will be removed in future.
+      extend Deprecation
+
+      MAX_LENGTH_LEGACY = 140
+
+      # DEPRECATED: Please use parse_text instead.
+      #
+      # Returns the length of the string as it would be displayed. This is equivilent to the length of the Unicode NFC
+      # (See: http://www.unicode.org/reports/tr15). This is needed in order to consistently calculate the length of a
+      # string no matter which actual form was transmitted. For example:
+      #
+      #     U+0065  Latin Small Letter E
+      # +   U+0301  Combining Acute Accent
+      # ----------
+      # =   2 bytes, 2 characters, displayed as é (1 visual glyph)
+      #     … The NFC of {U+0065, U+0301} is {U+00E9}, which is a single chracter and a +display_length+ of 1
+      #
+      # The string could also contain U+00E9 already, in which case the canonicalization will not change the value.
+      #
+      def tweet_length(text, options = {})
+        options = DEFAULT_TCO_URL_LENGTHS.merge(options)
+
+        length = text.to_nfc.unpack("U*").length
+
+        Twitter::TwitterText::Extractor.extract_urls_with_indices(text) do |url, start_position, end_position|
+          length += start_position - end_position
+          length += options[:short_url_length] if url.length > 0
+        end
+
+        length
+      end
+      deprecate :tweet_length, :parse_tweet
+
+      # DEPRECATED: Please use parse_text instead.
+      #
+      # Check the <tt>text</tt> for any reason that it may not be valid as a Tweet. This is meant as a pre-validation
+      # before posting to api.twitter.com. There are several server-side reasons for Tweets to fail but this pre-validation
+      # will allow quicker feedback.
+      #
+      # Returns <tt>false</tt> if this <tt>text</tt> is valid. Otherwise one of the following Symbols will be returned:
+      #
+      #   <tt>:too_long</tt>:: if the <tt>text</tt> is too long
+      #   <tt>:empty</tt>:: if the <tt>text</tt> is nil or empty
+      #   <tt>:invalid_characters</tt>:: if the <tt>text</tt> contains non-Unicode or any of the disallowed Unicode characters
+      def tweet_invalid?(text)
+        return :empty if !text || text.empty?
+        begin
+          return :too_long if tweet_length(text) > MAX_LENGTH_LEGACY
+          return :invalid_characters if Twitter::TwitterText::Regex::INVALID_CHARACTERS.any?{|invalid_char| text.include?(invalid_char) }
+        rescue ArgumentError
+          # non-Unicode value.
+          return :invalid_characters
+        end
+
+        return false
+      end
+      deprecate :tweet_invalid?, :parse_tweet
+
+      def valid_tweet_text?(text)
+        !tweet_invalid?(text)
+      end
+      deprecate :valid_tweet_text?, :parse_tweet
+
+      private
+
+      def valid_match?(string, regex, optional=false)
+        return (string && string.match(regex) && $~.to_s == string) unless optional
+
+        !(string && (!string.match(regex) || $~.to_s != string))
+      end
     end
   end
 end

--- a/rb/lib/twitter-text/weighted_range.rb
+++ b/rb/lib/twitter-text/weighted_range.rb
@@ -1,18 +1,20 @@
 # encoding: UTF-8
 
 module Twitter
-  class WeightedRange
-    attr_reader :start, :end, :weight
+  module TwitterText
+    class WeightedRange
+      attr_reader :start, :end, :weight
 
-    def initialize(range = {})
-      raise ArgumentError.new("Invalid range") unless [:start, :end, :weight].all? { |key| range.key?(key) && range[key].is_a?(Integer) }
-      @start = range[:start]
-      @end = range[:end]
-      @weight = range[:weight]
-    end
+      def initialize(range = {})
+        raise ArgumentError.new("Invalid range") unless [:start, :end, :weight].all? { |key| range.key?(key) && range[key].is_a?(Integer) }
+        @start = range[:start]
+        @end = range[:end]
+        @weight = range[:weight]
+      end
 
-    def contains?(code_point)
-      code_point >= @start && code_point <= @end
+      def contains?(code_point)
+        code_point >= @start && code_point <= @end
+      end
     end
   end
 end

--- a/rb/spec/autolinking_spec.rb
+++ b/rb/spec/autolinking_spec.rb
@@ -2,10 +2,10 @@
 require File.dirname(__FILE__) + '/spec_helper'
 
 class TestAutolink
-  include Twitter::Autolink
+  include Twitter::TwitterText::Autolink
 end
 
-describe Twitter::Autolink do
+describe Twitter::TwitterText::Autolink do
   def original_text; end
   def url; end
 

--- a/rb/spec/configuration_spec.rb
+++ b/rb/spec/configuration_spec.rb
@@ -1,34 +1,34 @@
 # encoding: utf-8
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe Twitter::Configuration do
+describe Twitter::TwitterText::Configuration do
   context "configuration" do
     context "with invalid data" do
       it "should raise an exception" do
-        invalid_hash = Twitter::Configuration.parse_string("{\"version\":2,\"maxWeightedTweetLength\":280,\"scale\":100,\"defaultWeight\":200,\"transformedURLLength\":23,\"ranges\":[{\"start\":0,\"end\":true,\"weight\":false},{\"start\":8192,\"end\":8205,\"weight\":100},{\"start\":8208,\"end\":8223,\"weight\":100},{\"start\":8242,\"end\":8247,\"weight\":100}]}")
-        expect { Twitter::Configuration.new(invalid_hash) }.to raise_error(ArgumentError)
+        invalid_hash = Twitter::TwitterText::Configuration.parse_string("{\"version\":2,\"maxWeightedTweetLength\":280,\"scale\":100,\"defaultWeight\":200,\"transformedURLLength\":23,\"ranges\":[{\"start\":0,\"end\":true,\"weight\":false},{\"start\":8192,\"end\":8205,\"weight\":100},{\"start\":8208,\"end\":8223,\"weight\":100},{\"start\":8242,\"end\":8247,\"weight\":100}]}")
+        expect { Twitter::TwitterText::Configuration.new(invalid_hash) }.to raise_error(ArgumentError)
       end
     end
 
     context "with defaults" do
       before do
-        Twitter::Configuration.default_configuration = Twitter::Configuration.configuration_from_file(Twitter::Configuration::CONFIG_V2)
+        Twitter::TwitterText::Configuration.default_configuration = Twitter::TwitterText::Configuration.configuration_from_file(Twitter::TwitterText::Configuration::CONFIG_V2)
       end
 
       it "should define version constants" do
-        expect(Twitter::Configuration.const_defined?(:CONFIG_V1)).to be true
-        expect(Twitter::Configuration.const_defined?(:CONFIG_V2)).to be true
+        expect(Twitter::TwitterText::Configuration.const_defined?(:CONFIG_V1)).to be true
+        expect(Twitter::TwitterText::Configuration.const_defined?(:CONFIG_V2)).to be true
       end
 
       it "should define a default configuration" do
-        expect(Twitter::Configuration.default_configuration).to_not be_nil
-        expect(Twitter::Configuration.default_configuration.version).to eq(2)
+        expect(Twitter::TwitterText::Configuration.default_configuration).to_not be_nil
+        expect(Twitter::TwitterText::Configuration.default_configuration.version).to eq(2)
       end
     end
 
     context "with v1 configuration" do
       before do
-        @config = Twitter::Configuration.configuration_from_file(Twitter::Configuration::CONFIG_V1)
+        @config = Twitter::TwitterText::Configuration.configuration_from_file(Twitter::TwitterText::Configuration::CONFIG_V1)
       end
 
       it "should have a version" do
@@ -54,7 +54,7 @@ describe Twitter::Configuration do
 
     context "with v2 configuration" do
       before do
-        @config = Twitter::Configuration.configuration_from_file(Twitter::Configuration::CONFIG_V2)
+        @config = Twitter::TwitterText::Configuration.configuration_from_file(Twitter::TwitterText::Configuration::CONFIG_V2)
       end
 
       it "should have a version" do
@@ -80,7 +80,7 @@ describe Twitter::Configuration do
       it "should have a configured range" do
         expect(@config.ranges).to be_kind_of(Array)
         expect(@config.ranges.count).to be > 0
-        expect(@config.ranges[0]).to be_kind_of(Twitter::WeightedRange)
+        expect(@config.ranges[0]).to be_kind_of(Twitter::TwitterText::WeightedRange)
         weighted_range = @config.ranges[0]
         expect(weighted_range.start).to be_kind_of(Integer)
         expect(weighted_range.end).to be_kind_of(Integer)

--- a/rb/spec/extractor_spec.rb
+++ b/rb/spec/extractor_spec.rb
@@ -2,10 +2,10 @@
 require File.dirname(__FILE__) + '/spec_helper'
 
 class TestExtractor
-  include Twitter::Extractor
+  include Twitter::TwitterText::Extractor
 end
 
-describe Twitter::Extractor do
+describe Twitter::TwitterText::Extractor do
   before do
     @extractor = TestExtractor.new
   end
@@ -241,7 +241,7 @@ describe Twitter::Extractor do
       it "does not consider a long URL with protocol to be valid" do
         # maximum length of domain label is 32 chars.
         url = ("a" * 31) + "."
-        url *= (Twitter::Extractor::MAX_URL_LENGTH / 32)
+        url *= (Twitter::TwitterText::Extractor::MAX_URL_LENGTH / 32)
         url = "https://" + url + "com" # longer than 4096 (MAX_URL_LENGTH) chars
         expect(@extractor.is_valid_domain(url.length, url, true)).to be false
       end
@@ -249,7 +249,7 @@ describe Twitter::Extractor do
       it "does not consider a long URL without protocol to be valid" do
         # maximum length of domain label is 32 chars.
         url = ("a" * 31) + "."
-        url *= ((Twitter::Extractor::MAX_URL_LENGTH / 32) - 1)
+        url *= ((Twitter::TwitterText::Extractor::MAX_URL_LENGTH / 32) - 1)
         url = url + "com" # shorter than 4096 (MAX_URL_LENGTH) chars
         expect(@extractor.is_valid_domain(url.length, url, false)).to be true
         url = ("a" * (31 - "https://".length)) + "." + url
@@ -309,11 +309,11 @@ describe Twitter::Extractor do
         end
 
         it "should not allow the multiplication character" do
-          expect(@extractor.extract_hashtags("#pre#{Twitter::Unicode::U00D7}post")).to be == ["pre"]
+          expect(@extractor.extract_hashtags("#pre#{Twitter::TwitterText::Unicode::U00D7}post")).to be == ["pre"]
         end
 
         it "should not allow the division character" do
-          expect(@extractor.extract_hashtags("#pre#{Twitter::Unicode::U00F7}post")).to be == ["pre"]
+          expect(@extractor.extract_hashtags("#pre#{Twitter::TwitterText::Unicode::U00F7}post")).to be == ["pre"]
         end
       end
 

--- a/rb/spec/hithighlighter_spec.rb
+++ b/rb/spec/hithighlighter_spec.rb
@@ -2,10 +2,10 @@
 require File.dirname(__FILE__) + '/spec_helper'
 
 class TestHitHighlighter
-  include Twitter::HitHighlighter
+  include Twitter::TwitterText::HitHighlighter
 end
 
-describe Twitter::HitHighlighter do
+describe Twitter::TwitterText::HitHighlighter do
   describe "highlight" do
     before do
       @highlighter = TestHitHighlighter.new

--- a/rb/spec/regex_spec.rb
+++ b/rb/spec/regex_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "Twitter::Regex regular expressions" do
+describe "Twitter::TwitterText::Regex regular expressions" do
   describe "matching URLS" do
     TestUrls::VALID.each do |url|
       it "should match the URL #{url}" do
@@ -25,13 +25,13 @@ describe "Twitter::Regex regular expressions" do
     it "should match if less than 25 characters" do
       name = "Shuffleboard Community"
       expect(name.length).to be < 25
-      expect(name).to match(Twitter::Regex::REGEXEN[:list_name])
+      expect(name).to match(Twitter::TwitterText::Regex::REGEXEN[:list_name])
     end
 
     it "should not match if greater than 25 characters" do
       name = "Most Glorious Shady Meadows Shuffleboard Community"
       expect(name.length).to be > 25
-      expect(name).to match(Twitter::Regex[:list_name])
+      expect(name).to match(Twitter::TwitterText::Regex[:list_name])
     end
 
   end

--- a/rb/spec/rewriter_spec.rb
+++ b/rb/spec/rewriter_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe Twitter::Rewriter do
+describe Twitter::TwitterText::Rewriter do
   def original_text; end
   def url; end
 
@@ -19,7 +19,7 @@ describe Twitter::Rewriter do
 
   describe "rewrite usernames" do #{{{
     before do
-      @rewritten_text = Twitter::Rewriter.rewrite_usernames_or_lists(original_text, &method(:block))
+      @rewritten_text = Twitter::TwitterText::Rewriter.rewrite_usernames_or_lists(original_text, &method(:block))
     end
 
     context "username preceded by a space" do
@@ -120,7 +120,7 @@ describe Twitter::Rewriter do
 
   describe "rewrite lists" do #{{{
     before do
-      @rewritten_text = Twitter::Rewriter.rewrite_usernames_or_lists(original_text, &method(:block))
+      @rewritten_text = Twitter::TwitterText::Rewriter.rewrite_usernames_or_lists(original_text, &method(:block))
     end
 
     context "slug preceded by a space" do
@@ -201,7 +201,7 @@ describe Twitter::Rewriter do
 
   describe "rewrite hashtags" do #{{{
     before do
-      @rewritten_text = Twitter::Rewriter.rewrite_hashtags(original_text, &method(:block))
+      @rewritten_text = Twitter::TwitterText::Rewriter.rewrite_hashtags(original_text, &method(:block))
     end
 
     context "with an all numeric hashtag" do
@@ -338,7 +338,7 @@ describe Twitter::Rewriter do
     def url; "http://www.google.com"; end
 
     before do
-      @rewritten_text = Twitter::Rewriter.rewrite_urls(original_text, &method(:block))
+      @rewritten_text = Twitter::TwitterText::Rewriter.rewrite_urls(original_text, &method(:block))
     end
 
     context "when embedded in plain text" do
@@ -452,7 +452,7 @@ describe Twitter::Rewriter do
     context "with a URL ending in allowed punctuation" do
       it "does not consume ending punctuation" do
         %w| ? ! , . : ; ] ) } = \ ' |.each do |char|
-          expect(Twitter::Rewriter.rewrite_urls("#{url}#{char}") do |url|
+          expect(Twitter::TwitterText::Rewriter.rewrite_urls("#{url}#{char}") do |url|
             expect(url).to be == url
             "[rewritten]"
           end).to be == "[rewritten]#{char}"
@@ -463,7 +463,7 @@ describe Twitter::Rewriter do
     context "with a URL preceded in forbidden characters" do
       it "should be rewritten" do
         %w| \ ' / ! = |.each do |char|
-          expect(Twitter::Rewriter.rewrite_urls("#{char}#{url}") do |url|
+          expect(Twitter::TwitterText::Rewriter.rewrite_urls("#{char}#{url}") do |url|
             "[rewritten]" # should not be called here.
           end).to be == "#{char}[rewritten]"
         end

--- a/rb/spec/spec_helper.rb
+++ b/rb/spec/spec_helper.rb
@@ -24,13 +24,13 @@ end
 
 RSpec::Matchers.define :match_autolink_expression do
   match do |string|
-    !Twitter::Extractor.extract_urls(string).empty?
+    !Twitter::TwitterText::Extractor.extract_urls(string).empty?
   end
 end
 
 RSpec::Matchers.define :match_autolink_expression_in do |text|
   match do |url|
-    @match_data = Twitter::Regex[:valid_url].match(text)
+    @match_data = Twitter::TwitterText::Regex[:valid_url].match(text)
     @match_data && @match_data.to_s.strip == url
   end
 

--- a/rb/spec/unicode_spec.rb
+++ b/rb/spec/unicode_spec.rb
@@ -1,31 +1,31 @@
 # encoding: utf-8
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe Twitter::Unicode do
+describe Twitter::TwitterText::Unicode do
 
   it "should lazy-init constants" do
-    expect(Twitter::Unicode.const_defined?(:UFEB6)).to eq(false)
-    expect(Twitter::Unicode::UFEB6).to_not be_nil
-    expect(Twitter::Unicode::UFEB6).to be_kind_of(String)
-    expect(Twitter::Unicode.const_defined?(:UFEB6)).to eq(true)
+    expect(Twitter::TwitterText::Unicode.const_defined?(:UFEB6)).to eq(false)
+    expect(Twitter::TwitterText::Unicode::UFEB6).to_not be_nil
+    expect(Twitter::TwitterText::Unicode::UFEB6).to be_kind_of(String)
+    expect(Twitter::TwitterText::Unicode.const_defined?(:UFEB6)).to eq(true)
   end
 
   it "should return corresponding character" do
-    expect(Twitter::Unicode::UFEB6).to be == [0xfeb6].pack('U')
+    expect(Twitter::TwitterText::Unicode::UFEB6).to be == [0xfeb6].pack('U')
   end
 
   it "should allow lowercase notation" do
-    expect(Twitter::Unicode::Ufeb6).to be == Twitter::Unicode::UFEB6
-    expect(Twitter::Unicode::Ufeb6).to be === Twitter::Unicode::UFEB6
+    expect(Twitter::TwitterText::Unicode::Ufeb6).to be == Twitter::TwitterText::Unicode::UFEB6
+    expect(Twitter::TwitterText::Unicode::Ufeb6).to be === Twitter::TwitterText::Unicode::UFEB6
   end
 
   it "should allow underscore notation" do
-    expect(Twitter::Unicode::U_FEB6).to be == Twitter::Unicode::UFEB6
-    expect(Twitter::Unicode::U_FEB6).to be === Twitter::Unicode::UFEB6
+    expect(Twitter::TwitterText::Unicode::U_FEB6).to be == Twitter::TwitterText::Unicode::UFEB6
+    expect(Twitter::TwitterText::Unicode::U_FEB6).to be === Twitter::TwitterText::Unicode::UFEB6
   end
 
   it "should raise on invalid codepoints" do
-    expect(lambda { Twitter::Unicode::FFFFFF }).to raise_error(NameError)
+    expect(lambda { Twitter::TwitterText::Unicode::FFFFFF }).to raise_error(NameError)
   end
 
 end

--- a/rb/spec/validation_spec.rb
+++ b/rb/spec/validation_spec.rb
@@ -2,18 +2,18 @@
 require File.dirname(__FILE__) + '/spec_helper'
 
 class TestValidation
-  include Twitter::Validation
+  include Twitter::TwitterText::Validation
 end
 
-describe Twitter::Validation do
+describe Twitter::TwitterText::Validation do
 
   it "should disallow invalid BOM character" do
-    expect(TestValidation.new.tweet_invalid?("Bom:#{Twitter::Unicode::UFFFE}")).to be == :invalid_characters
-    expect(TestValidation.new.tweet_invalid?("Bom:#{Twitter::Unicode::UFEFF}")).to be == :invalid_characters
+    expect(TestValidation.new.tweet_invalid?("Bom:#{Twitter::TwitterText::Unicode::UFFFE}")).to be == :invalid_characters
+    expect(TestValidation.new.tweet_invalid?("Bom:#{Twitter::TwitterText::Unicode::UFEFF}")).to be == :invalid_characters
   end
 
   it "should disallow invalid U+FFFF character" do
-    expect(TestValidation.new.tweet_invalid?("Bom:#{Twitter::Unicode::UFFFF}")).to be == :invalid_characters
+    expect(TestValidation.new.tweet_invalid?("Bom:#{Twitter::TwitterText::Unicode::UFFFF}")).to be == :invalid_characters
   end
 
   it "should disallow direction change characters" do
@@ -42,7 +42,7 @@ describe Twitter::Validation do
 
   context "when returning results" do
     it "should properly create new fully-populated results from arguments" do
-      results = Twitter::Validation::ParseResults.new(weighted_length: 26, permillage: 92, valid: true, display_range_start: 0, display_range_end: 16, valid_range_start: 0, valid_range_end:16)
+      results = Twitter::TwitterText::Validation::ParseResults.new(weighted_length: 26, permillage: 92, valid: true, display_range_start: 0, display_range_end: 16, valid_range_start: 0, valid_range_end:16)
       expect(results).to_not be nil
       expect(results[:weighted_length]).to eq(26)
       expect(results[:permillage]).to eq(92)
@@ -54,7 +54,7 @@ describe Twitter::Validation do
     end
 
     it "should properly create empty results" do
-      results = Twitter::Validation::ParseResults.empty()
+      results = Twitter::TwitterText::Validation::ParseResults.empty()
       expect(results[:weighted_length]).to eq(0)
       expect(results[:permillage]).to eq(0)
       expect(results[:valid]).to be true

--- a/rb/test/conformance_test.rb
+++ b/rb/test/conformance_test.rb
@@ -15,10 +15,10 @@ $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'twitter-text'
 
 class ConformanceTest < Test::Unit::TestCase
-  include Twitter::Extractor
-  include Twitter::Autolink
-  include Twitter::HitHighlighter
-  include Twitter::Validation
+  include Twitter::TwitterText::Extractor
+  include Twitter::TwitterText::Autolink
+  include Twitter::TwitterText::HitHighlighter
+  include Twitter::TwitterText::Validation
 
   private
 

--- a/rb/twitter-text.gemspec
+++ b/rb/twitter-text.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "twitter-text"
-  s.version = "2.0.2"
+  s.version = "2.1.0"
   s.authors = ["David LaMacchia", "Sudheer Guntupalli", "Kaushik Lakshmikanth", "Jose Antonio Marquez Russo", "Lee Adams",
                "Yoshimasa Niwa"]
   s.email = ["opensource@twitter.com"]


### PR DESCRIPTION
The popular Twitter gem (https://github.com/sferik/twitter) uses the
Twitter::Configuration namespace and users are reporting that our new
Twitter::Configuration class is conflicting with that namespace.

This patch changes our top-level namespace from Twitter to
Twitter::TwitterText:: to resolve this conflict and prevent further
conflicts in the future. Because this is a breaking change for clients
written against older versions of the library, the version has been
bumped to 2.1. This namespace more closely matches the namespace we use
in our Java implementation, too (com.twitter.twittertext)

There's also a new CHANGELOG.md file that details important changes in
this revision and will be updated going forward.