### PR TITLE
Using Gson instead of Jackson to parse static json files. #232

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -254,6 +254,13 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.8.7</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.2</version>
     </dependency>
 
     <dependency>

--- a/java/src/main/java/com/twitter/twittertext/TwitterTextConfiguration.java
+++ b/java/src/main/java/com/twitter/twittertext/TwitterTextConfiguration.java
@@ -10,7 +10,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 
 /**
  * A class that represents the different configurations used by {@link TwitterTextParser}
@@ -63,31 +63,28 @@ public class TwitterTextConfiguration {
   @Nonnull
   public static TwitterTextConfiguration configurationFromJson(@Nonnull String json,
                                                                boolean isResource) {
-    // jackson's default serialization format is json
-    final ObjectMapper objectMapper = new ObjectMapper();
+    Gson gson = new Gson();
     TwitterTextConfiguration config;
-    try {
-      if (isResource) {
-        InputStream resourceStream = TwitterTextConfiguration.class.getResourceAsStream("/" + json);
-        // For whatever reason, this fails in some Samsung Galaxy J7 family of devices,
-        // try falling back to classloader.
-        if (resourceStream == null) {
-          resourceStream =
-              TwitterTextConfiguration.class.getClassLoader().getResourceAsStream(json);
-        }
-        try {
-          final Reader reader = new BufferedReader(new InputStreamReader(resourceStream));
-          config = objectMapper.readValue(reader, TwitterTextConfiguration.class);
-          // If an invalid resource is passed, use default config.
-        } catch (NullPointerException ex) {
-          return getDefaultConfig();
-        }
-      } else {
-        config = objectMapper.readValue(json, TwitterTextConfiguration.class);
+    if (isResource) {
+      InputStream resourceStream = TwitterTextConfiguration.class.getResourceAsStream("/" + json);
+      // For whatever reason, this fails in some Samsung Galaxy J7 family of devices,
+      // try falling back to classloader.
+      if (resourceStream == null) {
+        resourceStream =
+            TwitterTextConfiguration.class.getClassLoader().getResourceAsStream(json);
       }
-    // InputStreamReader can throw an NPE when the resource is null
-    } catch (IOException ex) {
-      config = getDefaultConfig();
+      try {
+        final Reader reader = new BufferedReader(new InputStreamReader(resourceStream));
+        config = gson.fromJson(reader, TwitterTextConfiguration.class);
+        // If an invalid resource is passed, use default config.
+      } catch (NullPointerException ex) {
+        return getDefaultConfig();
+      }
+    } else {
+      config = gson.fromJson(json, TwitterTextConfiguration.class);
+    }
+    if(config == null) {
+      return getDefaultConfig();
     }
     return config;
   }


### PR DESCRIPTION
`jackson-databind` dependency adds 11347 methods to bundle.
http://www.methodscount.com/?lib=com.fasterxml.jackson.core%3Ajackson-databind%3A2.8.7

This is devastating for android apps which usually aim to be below 64k method limit.
I have substituted it with Gson 2.8.2, which only adds around 1345 methods

http://www.methodscount.com/?lib=com.google.code.gson%3Agson%3A2.8.0

(this is for 2.8.0, this site doesn't show it for 2.8.2, but I have counted it locally with `dexcount-gradle-plugin` and it has 832 methods after being proguarded).