### PR TITLE
[All] Extract urls with a ccTLD but without a protocol/path.

### DIFF
--- a/conformance/extract.yml
+++ b/conformance/extract.yml
@@ -322,7 +322,7 @@ tests:
 
     - description: "Extract URLs without protocol not on (com|org|edu|gov|net) domains"
       text: "foo.baz foo.co.jp www.xxxxxxx.baz www.foo.co.uk wwwww.xxxxxxx foo.comm foo.somecom foo.govedu foo.jp"
-      expected: ["foo.co.jp", "www.foo.co.uk"]
+      expected: ["foo.co.jp", "www.foo.co.uk", "foo.jp"]
 
     - description: "Extract URLs without protocol on ccTLD with slash"
       text: "t.co/abcde bit.ly/abcde"
@@ -368,9 +368,9 @@ tests:
       text: "http://exampleこれは日本語です.com/path/index.html http://あああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああ.com/path/index.html"
       expected: ["http://exampleこれは日本語です.com/path/index.html"]
 
-    - description: "DO NOT extract short URLs without protocol on ccTLD domains without path"
+    - description: "Extract short URLs without protocol on ccTLD domains without path"
       text: "twitter.jp日本語it.so中国語foo.jp it.so foo.jp"
-      expected: []
+      expected: ["twitter.jp", "it.so", "foo.jp", "it.so", "foo.jp"]
 
     - description: "DO NOT extract invalid URL"
       text: "Hello http://xn--はじめよう.com/index.html"
@@ -543,7 +543,7 @@ tests:
 
     - description: "Extract URL before newline"
       text: "http://twitter.com\nhttp://example.com\nhttp://example.com/path\nexample.com/path\nit.so\nit.so/abcde"
-      expected: ["http://twitter.com", "http://example.com", "http://example.com/path", "example.com/path", "it.so/abcde"]
+      expected: ["http://twitter.com", "http://example.com", "http://example.com/path", "example.com/path", "it.so", "it.so/abcde"]
 
     - description: "DO NOT extract URL if preceded by $"
       text: "$http://twitter.com $twitter.com $http://t.co/abcde $t.co/abcde $t.co $TVI.CA $RBS.CA"

--- a/conformance/validate.yml
+++ b/conformance/validate.yml
@@ -218,39 +218,6 @@ tests:
       text: "example.com/path/to/resource?search=foo&lang=en"
       expected: true
 
-  lengths:
-    - description: "Count the number of characters"
-      text: "This is a test."
-      expected: 15
-
-    - description: "Count a URL starting with http:// as 23 characters"
-      text: "http://test.com"
-      expected: 23
-
-    - description: "Count a URL starting with https:// as 23 characters"
-      text: "https://test.com"
-      expected: 23
-
-    - description: "Count a URL without protocol as 23 characters"
-      text: "test.com"
-      expected: 23
-
-    - description: "Count multiple URLs correctly"
-      text: "Test https://test.com test https://test.com test.com test"
-      expected: 86
-
-    - description: "Count unicode chars outside the basic multilingual plane (double word)"
-      text: "\U00010000\U0010ffff"
-      expected: 2
-
-    - description: "Count unicode chars inside the basic multilingual plane"
-      text: "저찀쯿쿿"
-      expected: 4
-
-    - description: "Count a mix of single byte single word, and double word unicode characters"
-      text: "H\U0001f431☺"
-      expected: 3
-
   WeightedTweetsCounterTest:
     - description: "Regular Tweet with url"
       text: "Hi http://test.co"

--- a/java/README.md
+++ b/java/README.md
@@ -16,7 +16,7 @@ Bringing twitter-text-java into your project should be as simple as adding the f
     <dependency>
       <groupId>com.twitter.twittertext</groupId>
       <artifactId>twitter-text</artifactId>
-      <version>2.0.9</version> <!-- or whatever the latest version is -->
+      <version>2.0.10</version> <!-- or whatever the latest version is -->
     </dependency>
   </dependencies>
 ```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.twitter.twittertext</groupId>
   <artifactId>twitter-text</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.9</version>
+  <version>2.0.10</version>
   <name>Twitter Text Java library</name>
   <description>Text processing routines for Twitter Tweets</description>
   <url>https://github.com/twitter/twitter-text</url>

--- a/java/src/main/java/com/twitter/twittertext/Regex.java
+++ b/java/src/main/java/com/twitter/twittertext/Regex.java
@@ -147,16 +147,11 @@ public class Regex {
           URL_VALID_UNICODE_CHARS + "\\.)";
 
   private static final String URL_PUNYCODE = "(?:xn--[-0-9a-z]+)";
-  private static final String SPECIAL_URL_VALID_CCTLD = "(?:(?:" + "co|tv" + ")(?=[^a-z0-9@]|$))";
 
   private static final String URL_VALID_DOMAIN =
-    "(?:" +                                                   // subdomains + domain + TLD
-        URL_VALID_SUBDOMAIN + "+" + URL_VALID_DOMAIN_NAME +   // e.g. www.twitter.com, foo.co.jp ...
+    "(?:" +                                                   // optional sub-domain + domain + TLD
+        URL_VALID_SUBDOMAIN + "*" + URL_VALID_DOMAIN_NAME +   // e.g. twitter.com, foo.co.jp ...
         "(?:" + URL_VALID_GTLD + "|" + URL_VALID_CCTLD + "|" + URL_PUNYCODE + ")" +
-    ")" +
-    "|(?:" +                                                  // domain + gTLD + some ccTLD
-      URL_VALID_DOMAIN_NAME +                                 // e.g. twitter.com
-      "(?:" + URL_VALID_GTLD + "|" + URL_PUNYCODE + "|" + SPECIAL_URL_VALID_CCTLD + ")" +
     ")" +
     "|(?:" + "(?<=https?://)" +
       "(?:" +

--- a/java/src/main/java/com/twitter/twittertext/Validator.java
+++ b/java/src/main/java/com/twitter/twittertext/Validator.java
@@ -1,12 +1,10 @@
 package com.twitter.twittertext;
 
-import java.text.Normalizer;
-
 /**
  * A class for validating Tweet texts.
  */
 public class Validator {
-  public static final int MAX_TWEET_LENGTH = 140;
+  public static final int MAX_TWEET_LENGTH = 280;
 
   protected int shortUrlLength = 23;
   protected int shortUrlLengthHttps = 23;
@@ -14,25 +12,15 @@ public class Validator {
   private Extractor extractor = new Extractor();
 
   /**
-   * Returns the length of a given tweet text counting code points.
+   * Returns the weighted length of a given tweet text
    *
    * @param tweetText the source to mark as modified.
    * @return length of a tweet
-   * @deprecated This doesn't do weighted character count calculations, so use TwitterTextParser
-   * instead.
+   * @deprecated Use TwitterTextParser
    */
   @Deprecated
   public int getTweetLength(String tweetText) {
-    final String text = Normalizer.normalize(tweetText, Normalizer.Form.NFC);
-    int length = text.codePointCount(0, text.length());
-
-    for (Extractor.Entity urlEntity : extractor.extractURLsWithIndices(text)) {
-      length += urlEntity.start - urlEntity.end;
-      length += urlEntity.value.toLowerCase().startsWith("https://") ?
-          shortUrlLengthHttps : shortUrlLength;
-    }
-
-    return length;
+    return TwitterTextParser.parseTweet(tweetText).weightedLength;
   }
 
   /**
@@ -41,8 +29,7 @@ public class Validator {
    */
   @Deprecated
   public boolean isValidTweet(String text) {
-    return text != null && text.length() != 0 && !hasInvalidCharacters(text) &&
-        getTweetLength(text) <= MAX_TWEET_LENGTH;
+    return TwitterTextParser.parseTweet(text).isValid;
   }
 
   public static boolean hasInvalidCharacters(String text) {

--- a/java/src/test/java/com/twitter/twittertext/ConformanceTest.java
+++ b/java/src/test/java/com/twitter/twittertext/ConformanceTest.java
@@ -401,24 +401,7 @@ public class ConformanceTest {
     }
   }
 
-  @RunWith(Parameterized.class)
-  public static class TweetLengthConformanceTest {
-    @Parameter
-    public Map testCase;
-
-    @Parameters
-    public static Collection<Map> data() throws Exception {
-      return loadConformanceData("validate.yml", "lengths");
-    }
-
-    @Test
-    public void testTweetLengthExtractor() throws Exception {
-      assertEquals((String) testCase.get(KEY_DESCRIPTION),
-          testCase.get(KEY_EXPECTED_OUTPUT),
-          VALIDATOR.getTweetLength((String) testCase.get(KEY_INPUT)));
-    }
-  }
-
+  @SuppressWarnings("deprecation")
   @RunWith(Parameterized.class)
   public static class WeightedTweetsConformanceTest {
     @Parameter
@@ -443,28 +426,6 @@ public class ConformanceTest {
       assertEquals(message, expected.get("displayRangeEnd"), parseResults.displayTextRange.end);
       assertEquals(message, expected.get("validRangeStart"), parseResults.validTextRange.start);
       assertEquals(message, expected.get("validRangeEnd"), parseResults.validTextRange.end);
-    }
-  }
-
-  @RunWith(Parameterized.class)
-  public static class V1TweetLengthConformanceTest {
-    @Parameter
-    public Map testCase;
-
-    @Parameters
-    public static Collection<Map> data() throws Exception {
-      return loadConformanceData("validate.yml", "lengths");
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testV1TweetLength() throws Exception {
-      final TwitterTextParseResults parseResults =
-          TwitterTextParser.parseTweet((String) testCase.get(KEY_INPUT),
-              TwitterTextParser.TWITTER_TEXT_DEFAULT_CONFIG);
-      assertEquals((String) testCase.get(KEY_DESCRIPTION),
-          testCase.get(KEY_EXPECTED_OUTPUT),
-          parseResults.weightedLength);
     }
   }
 

--- a/java/src/test/java/com/twitter/twittertext/RegexTest.java
+++ b/java/src/test/java/com/twitter/twittertext/RegexTest.java
@@ -99,10 +99,10 @@ public class RegexTest extends TestCase {
     assertTrue("Matching a URL with gTLD followed by ccTLD without protocol.",
         Regex.VALID_URL.matcher("www.foo.org.za").matches());
 
-    assertTrue("Should not match a short URL with ccTLD without protocol.",
+    assertTrue("Match a short URL with ccTLD with protocol.",
         Regex.VALID_URL.matcher("http://t.co").matches());
 
-    assertFalse("Should not match a short URL with ccTLD without protocol.",
+    assertTrue("Match a short URL with ccTLD without protocol.",
         Regex.VALID_URL.matcher("it.so").matches());
 
     assertFalse("Should not match a URL with invalid gTLD.",

--- a/java/src/test/java/com/twitter/twittertext/ValidatorTest.java
+++ b/java/src/test/java/com/twitter/twittertext/ValidatorTest.java
@@ -2,6 +2,7 @@ package com.twitter.twittertext;
 
 import junit.framework.TestCase;
 
+@SuppressWarnings("deprecation")
 public class ValidatorTest extends TestCase {
   protected Validator validator = new Validator();
 
@@ -27,7 +28,7 @@ public class ValidatorTest extends TestCase {
   public void testAccentCharacters() {
     String c = "\u0065\u0301";
     StringBuilder builder = new StringBuilder();
-    for (int i = 0; i < 139; i++) {
+    for (int i = 0; i < 279; i++) {
       builder.append(c);
     }
     assertTrue(validator.isValidTweet(builder.toString()));

--- a/js/src/extractUrlsWithIndices.js
+++ b/js/src/extractUrlsWithIndices.js
@@ -1,9 +1,7 @@
 import extractUrl from './regexp/extractUrl';
-import invalidShortDomain from './regexp/invalidShortDomain';
 import invalidUrlWithoutProtocolPrecedingChars from './regexp/invalidUrlWithoutProtocolPrecedingChars';
 import idna from './lib/idna';
 import validAsciiDomain from './regexp/validAsciiDomain';
-import validSpecialShortDomain from './regexp/validSpecialShortDomain';
 import validTcoUrl from './regexp/validTcoUrl';
 
 const DEFAULT_PROTOCOL = 'https://';
@@ -45,9 +43,7 @@ const extractUrlsWithIndices = function (text, options = DEFAULT_PROTOCOL_OPTION
           url: asciiDomain,
           indices: [ startPosition + asciiStartPosition, startPosition + asciiEndPosition ]
         };
-        if (path || asciiDomain.match(validSpecialShortDomain) || !asciiDomain.match(invalidShortDomain)) {
-          urls.push(lastUrl);
-        }
+        urls.push(lastUrl);
       });
 
       // no ASCII-only domain found. Skip the entire URL.

--- a/js/src/regexp/index.js
+++ b/js/src/regexp/index.js
@@ -17,7 +17,6 @@ import hashtagSpecialChars from './hashtagSpecialChars';
 import invalidChars from './invalidChars';
 import invalidCharsGroup from './invalidCharsGroup';
 import invalidDomainChars from './invalidDomainChars';
-import invalidShortDomain from './invalidShortDomain';
 import invalidUrlWithoutProtocolPrecedingChars from './invalidUrlWithoutProtocolPrecedingChars';
 import latinAccentChars from './latinAccentChars';
 import nonBmpCodePairs from './nonBmpCodePairs';
@@ -68,8 +67,6 @@ import validMentionPrecedingChars from './validMentionPrecedingChars';
 import validPortNumber from './validPortNumber';
 import validPunycode from './validPunycode';
 import validReply from './validReply';
-import validSpecialCCTLD from './validSpecialCCTLD';
-import validSpecialShortDomain from './validSpecialShortDomain';
 import validSubdomain from './validSubdomain';
 import validTcoUrl from './validTcoUrl';
 import validUrlBalancedParens from './validUrlBalancedParens';
@@ -99,7 +96,6 @@ export default {
   invalidChars,
   invalidCharsGroup,
   invalidDomainChars,
-  invalidShortDomain,
   invalidUrlWithoutProtocolPrecedingChars,
   latinAccentChars,
   nonBmpCodePairs,
@@ -150,8 +146,6 @@ export default {
   validPortNumber,
   validPunycode,
   validReply,
-  validSpecialCCTLD,
-  validSpecialShortDomain,
   validSubdomain,
   validTcoUrl,
   validUrlBalancedParens,

--- a/js/test/conformance.html
+++ b/js/test/conformance.html
@@ -134,10 +134,6 @@
               return function(test) {
                 return twttr.txt.isValidUrl(test.text, true, false);
               };
-            case "lengths":
-              return function(test) {
-                return twttr.txt.getTweetLength(test.text, twttr.txt.configs.version1);
-              };
             case "WeightedTweetsCounterTest":
               return function(test){
                 return twttr.txt.parseTweet(test.text);

--- a/js/test/tests.js
+++ b/js/test/tests.js
@@ -178,7 +178,7 @@ test("twttr.txt.autolink", function() {
   deepEqual(twttr.txt.autoLinkEntities("twitter.com", twttr.txt.extractEntitiesWithIndices("twitter.com")),
       "<a href=\"http://twitter.com\" rel=\"nofollow\">twitter.com</a>", "AutoLink with extractUrlsWithoutProtocol");
   deepEqual(twttr.txt.autoLinkEntities("TWITTER.JP", twttr.txt.extractEntitiesWithIndices("TWITTER.JP")),
-      "TWITTER.JP", "Do not AutoLink withoutProtocol just because domain is uppercase");
+      "<a href=\"http://TWITTER.JP\" rel=\"nofollow\">TWITTER.JP</a>", "AutoLink with extractUrlsWithoutProtocol with ccTLD domains");
 
   // url entities
   autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {

--- a/objc/lib/TwitterText.m
+++ b/objc/lib/TwitterText.m
@@ -125,18 +125,13 @@
 #define TWUValidURLUnicodeDomain        @"(?:(?:" TWUValidURLUnicodeCharacters @"[" TWUValidURLUnicodeCharacters @"\\-]{0,255})?" TWUValidURLUnicodeCharacters @"\\.)"
 
 #define TWUValidPunycode                @"(?:xn--[-0-9a-z]+)"
-#define TWUValidSpecialCCTLD            @"(?:(?:co|tv)(?=[^a-z0-9@]|$))"
 
 #define TWUValidDomain \
 @"(?:" \
-    TWUValidURLSubdomain @"+" TWUValidURLDomain \
+    TWUValidURLSubdomain @"*" TWUValidURLDomain \
     @"(?:" TWUValidGTLD @"|" TWUValidCCTLD @"|" TWUValidPunycode @")" \
 @")" \
-@"|(?:" \
-    TWUValidURLDomain \
-    @"(?:" TWUValidGTLD @"|" TWUValidPunycode @"|" TWUValidSpecialCCTLD @")" \
-  @")" \
-  @"|(?:(?<=https?://)" \
+@"|(?:(?<=https?://)" \
   @"(?:" \
     @"(?:" TWUValidURLDomain TWUValidCCTLD @")" \
     @"|(?:" \
@@ -430,7 +425,7 @@ typedef NSInteger (^TextUnitCounterBlock)(NSInteger currentLength, NSString* tex
         NSInteger start = urlRange.location;
         NSInteger end = NSMaxRange(urlRange);
 
-        NSTextCheckingResult *tcoResult = [[self validTCOURLRegexp] firstMatchInString:url options:0 range:NSMakeRange(0, url.length)];
+        NSTextCheckingResult *tcoResult = url ? [[self validTCOURLRegexp] firstMatchInString:url options:0 range:NSMakeRange(0, url.length)] : nil;
         if (tcoResult && tcoResult.numberOfRanges >= 2) {
             NSRange tcoRange = [tcoResult rangeAtIndex:0];
             NSRange tcoUrlSlugRange = [tcoResult rangeAtIndex:1];

--- a/objc/tests/TwitterTextTests.m
+++ b/objc/tests/TwitterTextTests.m
@@ -481,36 +481,6 @@
     }
 }
 
-- (void)testValidate
-{
-    NSString *fileName = [[[self class] conformanceRootDirectory] stringByAppendingPathComponent:@"validate.json"];
-    NSData *data = [NSData dataWithContentsOfFile:fileName];
-    if (!data) {
-        XCTFail(@"No test data: %@", fileName);
-        return;
-    }
-    NSDictionary *rootDic = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
-    if (!rootDic) {
-        XCTFail(@"Invalid test data: %@", fileName);
-        return;
-    }
-
-    [TwitterTextParser setDefaultParserWithConfiguration:[TwitterTextConfiguration configurationFromJSONResource:kTwitterTextParserConfigurationClassic]];
-
-    NSDictionary *tests = [rootDic objectForKey:@"tests"];
-    NSArray *lengths = [tests objectForKey:@"lengths"];
-
-    for (NSDictionary *testCase in lengths) {
-        NSString *text = [testCase objectForKey:@"text"];
-        text = [self stringByParsingUnicodeEscapes:text];
-        NSUInteger expected = [[testCase objectForKey:@"expected"] unsignedIntegerValue];
-        NSUInteger len = [TwitterText tweetLength:text];
-        TwitterTextParseResults *results = [[TwitterTextParser defaultParser] parseTweet:text];
-        XCTAssertEqual(len, results.weightedLength, "TwitterTextParser with classic configuration is not compatible with TwitterText for string %@", text);
-        XCTAssertEqual(len, expected, @"Length should be the same");
-    }
-}
-
 - (void)testWeightedTweetsCounting
 {
     NSString *fileName = [[[self class] conformanceRootDirectory] stringByAppendingPathComponent:@"validate.json"];

--- a/objc/tests/json-conformance/extract.json
+++ b/objc/tests/json-conformance/extract.json
@@ -574,7 +574,8 @@
         "text": "foo.baz foo.co.jp www.xxxxxxx.baz www.foo.co.uk wwwww.xxxxxxx foo.comm foo.somecom foo.govedu foo.jp",
         "expected": [
           "foo.co.jp",
-          "www.foo.co.uk"
+          "www.foo.co.uk",
+          "foo.jp"
         ]
       },
       {
@@ -669,10 +670,14 @@
         ]
       },
       {
-        "description": "DO NOT extract short URLs without protocol on ccTLD domains without path",
+        "description": "Extract short URLs without protocol on ccTLD domains without path",
         "text": "twitter.jp日本語it.so中国語foo.jp it.so foo.jp",
         "expected": [
-
+          "twitter.jp",
+          "it.so",
+          "foo.jp",
+          "it.so",
+          "foo.jp"
         ]
       },
       {
@@ -981,6 +986,7 @@
           "http://example.com",
           "http://example.com/path",
           "example.com/path",
+          "it.so",
           "it.so/abcde"
         ]
       },

--- a/objc/tests/json-conformance/validate.json
+++ b/objc/tests/json-conformance/validate.json
@@ -277,48 +277,6 @@
         "expected": true
       }
     ],
-    "lengths": [
-      {
-        "description": "Count the number of characters",
-        "text": "This is a test.",
-        "expected": 15
-      },
-      {
-        "description": "Count a URL starting with http:// as 23 characters",
-        "text": "http://test.com",
-        "expected": 23
-      },
-      {
-        "description": "Count a URL starting with https:// as 23 characters",
-        "text": "https://test.com",
-        "expected": 23
-      },
-      {
-        "description": "Count a URL without protocol as 23 characters",
-        "text": "test.com",
-        "expected": 23
-      },
-      {
-        "description": "Count multiple URLs correctly",
-        "text": "Test https://test.com test https://test.com test.com test",
-        "expected": 86
-      },
-      {
-        "description": "Count unicode chars outside the basic multilingual plane (double word)",
-        "text": "𐀀􏿿",
-        "expected": 2
-      },
-      {
-        "description": "Count unicode chars inside the basic multilingual plane",
-        "text": "저찀쯿쿿",
-        "expected": 4
-      },
-      {
-        "description": "Count a mix of single byte single word, and double word unicode characters",
-        "text": "H🐱☺",
-        "expected": 3
-      }
-    ],
     "WeightedTweetsCounterTest": [
       {
         "description": "Regular Tweet with url",

--- a/rb/lib/twitter-text/extractor.rb
+++ b/rb/lib/twitter-text/extractor.rb
@@ -218,11 +218,7 @@ module Twitter
                 :indices => [start_position + $~.char_begin(0),
                              start_position + $~.char_end(0)]
               }
-              if path ||
-                 ascii_domain =~ Twitter::TwitterText::Regex[:valid_special_short_domain] ||
-                 ascii_domain !~ Twitter::TwitterText::Regex[:invalid_short_domain]
-                urls << last_url
-              end
+              urls << last_url
             end
 
             # no ASCII-only domain found. Skip the entire URL

--- a/rb/lib/twitter-text/regex.rb
+++ b/rb/lib/twitter-text/regex.rb
@@ -183,13 +183,6 @@ module Twitter
       }ix
       REGEXEN[:valid_punycode] = /(?:xn--[0-9a-z]+)/i
 
-      REGEXEN[:valid_special_cctld] = %r{
-        (?:
-          (?:co|tv)
-          (?=[^0-9a-z@]|$)
-        )
-      }ix
-
       REGEXEN[:valid_domain] = /(?:
         #{REGEXEN[:valid_subdomain]}*#{REGEXEN[:valid_domain_name]}
         (?:#{REGEXEN[:valid_gTLD]}|#{REGEXEN[:valid_ccTLD]}|#{REGEXEN[:valid_punycode]})
@@ -203,10 +196,6 @@ module Twitter
 
       # This is used in Extractor for stricter t.co URL extraction
       REGEXEN[:valid_tco_url] = /^https?:\/\/t\.co\/([a-z0-9]+)/i
-
-      # This is used in Extractor to filter out unwanted URLs.
-      REGEXEN[:invalid_short_domain] = /\A#{REGEXEN[:valid_domain_name]}#{REGEXEN[:valid_ccTLD]}\Z/io
-      REGEXEN[:valid_special_short_domain] = /\A#{REGEXEN[:valid_domain_name]}#{REGEXEN[:valid_special_cctld]}\Z/io
 
       REGEXEN[:valid_port_number] = /[0-9]+/
 


### PR DESCRIPTION
[Java] Proxy deprecated Validator methods to use TwitterTextParser.