### PR TITLE
Use substring instead of startsWith for punycode check

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twitter-text",
   "description": "official twitter text linkification",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "build/twitter-text.js",
   "files": [
     "build/twitter-text.js"

--- a/js/src/lib/idna.js
+++ b/js/src/lib/idna.js
@@ -2,13 +2,13 @@ import punycode from 'punycode';
 import validAsciiDomain from '../regexp/validAsciiDomain';
 
 const MAX_DOMAIN_LABEL_LENGTH = 63;
-
+const PUNYCODE_ENCODED_DOMAIN_PREFIX = 'xn--';
 // This is an extremely lightweight implementation of domain name validation according to RFC 3490
 // Our regexes handle most of the cases well enough
 // See https://tools.ietf.org/html/rfc3490#section-4.1 for details
 const idna = {
   toAscii: function(domain) {
-    if (domain.startsWith('xn--') && !domain.match(validAsciiDomain)) {
+    if ((domain.substring(0, 4) === PUNYCODE_ENCODED_DOMAIN_PREFIX) && !domain.match(validAsciiDomain)) {
       // Punycode encoded url cannot contain non ASCII characters
       return;
     }


### PR DESCRIPTION
startsWith needs a polyfill on older browsers. We don't really need it as substring works fine. Links #242.