### PR TITLE
Update for 2.0.4 objc release

### DIFF
--- a/objc/CHANGELOG.md
+++ b/objc/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.4] - 2018-01-26
+### Changed
+- Domains with country code TLDs that are not prefixed by a protocol
+  will now be extracted as a URL entity. Previously .cc and .tv were
+  special-cased. This may result in some tweets getting longer: a
+  short domain like "twitter.co" will be counted as 23 characters.
+
 ## [2.0.3] - 2018-01-12
 ### Changed
 - Made initWithConfiguration: public (Issue #236)


### PR DESCRIPTION
Includes the following:
- Domains with country code TLDs that are not prefixed by a protocol
  will now be extracted as a URL entity. Previously .cc and .tv were
  special-cased. This may result in some tweets getting longer: a
  short domain like "twitter.co" will be counted as 23 characters.