### PR TITLE
using default emoji config

### DIFF
--- a/java/src/main/java/com/twitter/twittertext/TwitterTextParser.java
+++ b/java/src/main/java/com/twitter/twittertext/TwitterTextParser.java
@@ -62,7 +62,7 @@ public final class TwitterTextParser {
    */
   @Nonnull
   public static TwitterTextParseResults parseTweet(@Nullable final String tweet) {
-    return parseTweet(tweet, TWITTER_TEXT_WEIGHTED_CHAR_COUNT_CONFIG);
+    return parseTweet(tweet, TWITTER_TEXT_DEFAULT_CONFIG);
   }
 
   /**
@@ -88,7 +88,7 @@ public final class TwitterTextParser {
   @Nonnull
   public static TwitterTextParseResults parseTweetWithoutUrlExtraction(
       @Nullable final String tweet) {
-    return parseTweet(tweet, TWITTER_TEXT_WEIGHTED_CHAR_COUNT_CONFIG, false);
+    return parseTweet(tweet, TWITTER_TEXT_DEFAULT_CONFIG, false);
   }
 
   /**


### PR DESCRIPTION
Most of the methods use these utils. so by default they should use TWITTER_TEXT_DEFAULT_CONFIG

Problem

By default com.twitter.twittertext.Validator#isValidTweet must use emoji parsing enabled config
so that emoji char count matches in both java nad js

Solution

as TWITTER_TEXT_DEFAULT_CONFIG is already set, we must use that in default method to avoid confusion 
Result

this will greatly avoid confusion and developer need not modify any code to use it