### PR TITLE
Ruby: Fix auto_link so that it doesn't remove emoji

### DIFF
--- a/rb/lib/twitter-text/autolink.rb
+++ b/rb/lib/twitter-text/autolink.rb
@@ -81,6 +81,8 @@ module Twitter
             link_to_screen_name(entity, chars, options, &block)
           elsif entity[:cashtag]
             link_to_cashtag(entity, chars, options, &block)
+          elsif entity[:emoji]
+            entity[:emoji]
           end
         end
       end

--- a/rb/spec/autolinking_spec.rb
+++ b/rb/spec/autolinking_spec.rb
@@ -18,6 +18,16 @@ describe Twitter::TwitterText::Autolink do
       @autolinked_text = TestAutolink.new.auto_link(original_text) if original_text
     end
 
+    describe "plain text" do
+      context "plain text with emoji" do
+        def original_text; "gotcha 👍"; end
+
+        it "should be unchanged" do
+          expect(@autolinked_text).to eq("gotcha 👍")
+        end
+      end
+    end
+
     describe "username autolinking" do
       context "username preceded by a space" do
         def original_text; "hello @jacob"; end


### PR DESCRIPTION
This fixes twitter/twitter-text#275