### PR TITLE
Ruby: Remove deprecated `has_rdoc` call

### DIFF
--- a/rb/twitter-text.gemspec
+++ b/rb/twitter-text.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.license = "Apache 2.0"
 
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
   s.summary = "Twitter text handling library"
 
   s.add_development_dependency "test-unit"


### PR DESCRIPTION
To stop the following warning appearing when you install the rub gem

> NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement.
> It will be removed on or after 2018-12-01.  Gem::Specification#has_rdoc=
> called from twitter-text/rb/twitter-text.gemspec:18.
