### PR TITLE
Fix inconsistent date format in java/CHANGELOG.md

### DIFF
--- a/java/CHANGELOG.md
+++ b/java/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [3.1.0] - 2020-27-03
+## [3.1.0] - 2020-03-27
 ### Removed
 - Stopped reading data files (JSON) for configuration in order to remove
   heavyweight dependency on Jackson.

--- a/java/CHANGELOG.md
+++ b/java/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - Stopped reading data files (JSON) for configuration in order to remove
   heavyweight dependency on Jackson.
-- Defaulted configuraiton to the values in the v3.json files still used
+- Defaulted configuration to the values in the v3.json files still used
   by the other language implementations.
 - Removed proguard configuration since it was about protecting data files
   from obfuscation.


### PR DESCRIPTION
Problem

The date format in java/CHANGELOG.md is inconsistent. All the dates in other CHANGELOG.md files are written in the format yyyy-mm-dd.

Solution

Fix the incorrect date in java/CHANGELOG.md. Also fixes a small typo.

