### PR TITLE
Update gem to support frozen string literal

### DIFF
--- a/rb/CHANGELOG.md
+++ b/rb/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fully support frozen_string_literal: true
 
 ## [3.1.0]
 ### Changed

--- a/rb/Gemfile
+++ b/rb/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "http://rubygems.org"
 
 # Specify the gem's dependencies in twitter-text.gemspec

--- a/rb/lib/twitter-text.rb
+++ b/rb/lib/twitter-text.rb
@@ -1,6 +1,7 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the Apache License, Version 2.0
 # http://www.apache.org/licenses/LICENSE-2.0
+# frozen_string_literal: true
 
 major, minor, _patch = RUBY_VERSION.split('.')
 

--- a/rb/lib/twitter-text/autolink.rb
+++ b/rb/lib/twitter-text/autolink.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'set'
 require 'twitter-text/hash_helper'
@@ -325,10 +326,10 @@ module Twitter
           #   <span style='font-size:0'>&nbsp;</span>
           #   …
           # </span>
-          %(<span class="tco-ellipsis">#{preceding_ellipsis}<span #{invisible_tag_attrs}>&nbsp;</span></span>) <<
-            %(<span #{invisible_tag_attrs}>#{html_escape(before_display_url)}</span>) <<
-            %(<span class="js-display-url">#{html_escape(display_url_sans_ellipses)}</span>) <<
-            %(<span #{invisible_tag_attrs}>#{html_escape(after_display_url)}</span>) <<
+          %(<span class="tco-ellipsis">#{preceding_ellipsis}<span #{invisible_tag_attrs}>&nbsp;</span></span>) +
+            %(<span #{invisible_tag_attrs}>#{html_escape(before_display_url)}</span>) +
+            %(<span class="js-display-url">#{html_escape(display_url_sans_ellipses)}</span>) +
+            %(<span #{invisible_tag_attrs}>#{html_escape(after_display_url)}</span>) +
             %(<span class="tco-ellipsis"><span #{invisible_tag_attrs}>&nbsp;</span>#{following_ellipsis}</span>)
         else
           html_escape(display_url)
@@ -444,7 +445,7 @@ module Twitter
                     else
                       value
                     end
-            attrs << %( #{html_escape(key)}="#{html_escape(value)}")
+            attrs = attrs + %( #{html_escape(key)}="#{html_escape(value)}")
           end
 
           attrs

--- a/rb/lib/twitter-text/configuration.rb
+++ b/rb/lib/twitter-text/configuration.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: UTF-8
+# frozen_string_literal: true
 
 module Twitter
   module TwitterText

--- a/rb/lib/twitter-text/deprecation.rb
+++ b/rb/lib/twitter-text/deprecation.rb
@@ -8,7 +8,7 @@ module Twitter
       def deprecate(method, new_method = nil)
         deprecated_method = :"deprecated_#{method}"
         message = "Deprecation: `#{method}` is deprecated."
-        message << " Please use `#{new_method}` instead." if new_method
+        message += " Please use `#{new_method}` instead." if new_method
 
         alias_method(deprecated_method, method)
         define_method method do |*args, &block|

--- a/rb/lib/twitter-text/deprecation.rb
+++ b/rb/lib/twitter-text/deprecation.rb
@@ -1,6 +1,7 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the Apache License, Version 2.0
 # http://www.apache.org/licenses/LICENSE-2.0
+# frozen_string_literal: true
 
 module Twitter
   module TwitterText
@@ -8,7 +9,7 @@ module Twitter
       def deprecate(method, new_method = nil)
         deprecated_method = :"deprecated_#{method}"
         message = "Deprecation: `#{method}` is deprecated."
-        message += " Please use `#{new_method}` instead." if new_method
+        message = "#{message} Please use `#{new_method}` instead." if new_method
 
         alias_method(deprecated_method, method)
         define_method method do |*args, &block|

--- a/rb/lib/twitter-text/emoji_regex.rb
+++ b/rb/lib/twitter-text/emoji_regex.rb
@@ -6,6 +6,7 @@
 # DO NOT MODIFY THIS FILE -- it is generated for twitter-text automatically
 
 # encoding: utf-8
+# frozen_string_literal: true
 
 module Twitter
   module TwitterText

--- a/rb/lib/twitter-text/extractor.rb
+++ b/rb/lib/twitter-text/extractor.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 require 'idn'
 
 class String
@@ -19,7 +20,7 @@ class String
 
   # Helper function to convert this string into an array of unicode code points.
   def to_codepoint_a
-    @to_codepoint_a ||= if chars.kind_of?(Enumerable)
+    if chars.kind_of?(Enumerable)
       chars.to_a
     else
       codepoint_array = []

--- a/rb/lib/twitter-text/hash_helper.rb
+++ b/rb/lib/twitter-text/hash_helper.rb
@@ -1,6 +1,8 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the Apache License, Version 2.0
 # http://www.apache.org/licenses/LICENSE-2.0
+#
+# frozen_string_literal: true
 
 module Twitter
   module TwitterText

--- a/rb/lib/twitter-text/hit_highlighter.rb
+++ b/rb/lib/twitter-text/hit_highlighter.rb
@@ -1,6 +1,7 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the Apache License, Version 2.0
 # http://www.apache.org/licenses/LICENSE-2.0
+# frozen_string_literal: true
 
 module Twitter
   module TwitterText

--- a/rb/lib/twitter-text/regex.rb
+++ b/rb/lib/twitter-text/regex.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 
 module Twitter
   module TwitterText

--- a/rb/lib/twitter-text/rewriter.rb
+++ b/rb/lib/twitter-text/rewriter.rb
@@ -1,6 +1,7 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the Apache License, Version 2.0
 # http://www.apache.org/licenses/LICENSE-2.0
+# frozen_string_literal: true
 
 module Twitter
   module TwitterText

--- a/rb/lib/twitter-text/unicode.rb
+++ b/rb/lib/twitter-text/unicode.rb
@@ -1,6 +1,7 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the Apache License, Version 2.0
 # http://www.apache.org/licenses/LICENSE-2.0
+# frozen_string_literal: true
 
 module Twitter
   module TwitterText

--- a/rb/lib/twitter-text/validation.rb
+++ b/rb/lib/twitter-text/validation.rb
@@ -1,6 +1,8 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the Apache License, Version 2.0
 # http://www.apache.org/licenses/LICENSE-2.0
+#
+# frozen_string_literal: true
 
 require 'unf'
 

--- a/rb/lib/twitter-text/weighted_range.rb
+++ b/rb/lib/twitter-text/weighted_range.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: UTF-8
+# frozen_string_literal: true
 
 module Twitter
   module TwitterText

--- a/rb/spec/autolinking_spec.rb
+++ b/rb/spec/autolinking_spec.rb
@@ -3,6 +3,8 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
+
 require File.dirname(__FILE__) + '/spec_helper'
 
 class TestAutolink

--- a/rb/spec/configuration_spec.rb
+++ b/rb/spec/configuration_spec.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
 describe Twitter::TwitterText::Configuration do

--- a/rb/spec/extractor_spec.rb
+++ b/rb/spec/extractor_spec.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
 class TestExtractor

--- a/rb/spec/hithighlighter_spec.rb
+++ b/rb/spec/hithighlighter_spec.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
 class TestHitHighlighter

--- a/rb/spec/regex_spec.rb
+++ b/rb/spec/regex_spec.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
 describe "Twitter::TwitterText::Regex regular expressions" do

--- a/rb/spec/rewriter_spec.rb
+++ b/rb/spec/rewriter_spec.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
 describe Twitter::TwitterText::Rewriter do

--- a/rb/spec/spec_helper.rb
+++ b/rb/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the Apache License, Version 2.0
 # http://www.apache.org/licenses/LICENSE-2.0
+# frozen_string_literal: true
 
 $TESTING=true
 

--- a/rb/spec/test_urls.rb
+++ b/rb/spec/test_urls.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 
 module TestUrls
   VALID = [

--- a/rb/spec/twitter_text_spec.rb
+++ b/rb/spec/twitter_text_spec.rb
@@ -3,6 +3,8 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
+#
 require File.dirname(__FILE__) + '/spec_helper'
 
 major, minor, patch = RUBY_VERSION.split('.')

--- a/rb/spec/unicode_spec.rb
+++ b/rb/spec/unicode_spec.rb
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
 describe Twitter::TwitterText::Unicode do

--- a/rb/spec/validation_spec.rb
+++ b/rb/spec/validation_spec.rb
@@ -3,6 +3,8 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
+#
 require File.dirname(__FILE__) + '/spec_helper'
 
 class TestValidation

--- a/rb/test/conformance_test.rb
+++ b/rb/test/conformance_test.rb
@@ -1,6 +1,7 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the Apache License, Version 2.0
 # http://www.apache.org/licenses/LICENSE-2.0
+# frozen_string_literal: true
 
 require 'multi_json'
 require 'nokogiri'

--- a/rb/twitter-text.gemspec
+++ b/rb/twitter-text.gemspec
@@ -3,6 +3,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # encoding: utf-8
+# frozen_string_literal: true
 
 Gem::Specification.new do |s|
   s.name = "twitter-text"


### PR DESCRIPTION
Problem

As a user of the twitter-text gem, I want to turn on frozen_string_literal for my application, but the twitter-text gem does not support the setting, therefore I can not turn it on for my application.

see: https://www.mikeperham.com/2018/02/28/ruby-optimization-with-one-magic-comment/
 for more info.


Solution

1. Add the magic comment to all .rb files
2. Remove a couple of places we are using << operator on Strings
3. Change the String monkey patch to not modify instance state. 

Result
Running the tests as 

```bash
RUBYOPT=--enable-frozen-string-literal rake  
```

are green.
