### PR TITLE
Allow emoji domain names

### DIFF
--- a/rb/spec/test_urls.rb
+++ b/rb/spec/test_urls.rb
@@ -41,7 +41,9 @@ module TestUrls
     "http://foobar.中国",
     "http://foobar.پاکستان",
     "https://www.youtube.com/playlist?list=PL0ZPu8XSRTB7wZzn0mLHMvyzVFeRxbWn-",
-    "http://ああ.com"
+    "http://ああ.com",
+    "twitter.联通",
+    "https://🌈🌈🌈.st"
   ] unless defined?(TestUrls::VALID)
 
   INVALID = [

--- a/rb/twitter-text.gemspec
+++ b/rb/twitter-text.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "test-unit"
   s.add_development_dependency "multi_json", "~> 1.3"
-  s.add_development_dependency "nokogiri", "~> 1.10.9"
+  s.add_development_dependency "nokogiri", "~> 1.15.3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"
   s.add_development_dependency "rspec", "~> 3.0"

--- a/rb/twitter-text.gemspec
+++ b/rb/twitter-text.gemspec
@@ -25,8 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "simplecov"
   s.add_runtime_dependency     "unf", "~> 0.1.0"
-  # Use of idn-ruby requires libidn to be installed separately
-  s.add_runtime_dependency     "idn-ruby"
+  s.add_runtime_dependency     "simpleidn"
 
   s.files         = `git ls-files`.split("\n") + ['lib/assets/tld_lib.yml'] + Dir['config/*']
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Problem

Currently the ruby version of this library does not recognize links to domains that include emojis, even though browsers support those domains. Texts that include "https://🌈🌈🌈.st" will not be accepted as a valid URL. The problem comes from idn-ruby and libidn2, which does not recognize emoji characters as valid for domain names, even though they are registerable and work fine in browsers (after being translated into punycode).

Solution

I replaced idn-ruby with another rubygem that implements the punycode conversion in ruby directly without native dependencies and then added some validation that libidn2 did to pass the conformity test suite again.

Result

Texts that include "https://🌈🌈🌈.st" will now correctly identified as including a link. Note that currently there are more checks in this library that prevent "🌈🌈🌈.st" from being parsed as a link. While I would like to make that work as well, I felt like that would be too big of a change.
