### PR TITLE
Allow unicode domain name and path

### DIFF
--- a/java/src/main/java/com/twitter/twittertext/Regex.java
+++ b/java/src/main/java/com/twitter/twittertext/Regex.java
@@ -148,7 +148,8 @@ public class Regex {
   private static final String URL_VALID_PRECEDING_CHARS =
       "(?:[^a-z0-9@＠$#＃" + INVALID_CHARACTERS + "]|[" + DIRECTIONAL_CHARACTERS + "]|^)";
 
-  private static final String URL_VALID_CHARS = "[a-z0-9" + LATIN_ACCENTS_CHARS + "]";
+  private static final String URL_UNICODE_CHARS ="\\p{M}\\p{L}";
+  private static final String URL_VALID_CHARS = "[a-z0-9" + URL_UNICODE_CHARS +LATIN_ACCENTS_CHARS + "]";
   private static final String URL_VALID_SUBDOMAIN =
       "(?>(?:" + URL_VALID_CHARS + "[" + URL_VALID_CHARS + "\\-_]*)?" + URL_VALID_CHARS + "\\.)";
   private static final String URL_VALID_DOMAIN_NAME =
@@ -159,7 +160,7 @@ public class Regex {
   // Any non-space, non-punctuation characters.
   // \p{Z} = any kind of whitespace or invisible separator.
   private static final String URL_VALID_UNICODE_CHARS =
-      "[^" + PUNCTUATION_CHARS + "\\s\\p{Z}\\p{InGeneralPunctuation}]";
+      "[^" + PUNCTUATION_CHARS+ URL_UNICODE_CHARS + "\\s\\p{Z}\\p{InGeneralPunctuation}]";
   private static final String URL_VALID_UNICODE_DOMAIN_NAME =
       "(?:(?:" + URL_VALID_UNICODE_CHARS + "[" + URL_VALID_UNICODE_CHARS + "\\-]*)?" +
           URL_VALID_UNICODE_CHARS + "\\.)";
@@ -188,7 +189,7 @@ public class Regex {
 
   private static final String URL_VALID_GENERAL_PATH_CHARS =
       "[a-z0-9!\\*';:=\\+,.\\$/%#\\[\\]\\-\\u2013_~\\|&@" +
-          LATIN_ACCENTS_CHARS + CYRILLIC_CHARS + "]";
+          LATIN_ACCENTS_CHARS + CYRILLIC_CHARS + URL_UNICODE_CHARS + "]";
 
   /**
    * Allow URL paths to contain up to two nested levels of balanced parens
@@ -216,7 +217,7 @@ public class Regex {
    *   2. Allow =&# for empty URL parameters and other URL-join artifacts
    */
   private static final String URL_VALID_PATH_ENDING_CHARS =
-      "[a-z0-9=_#/\\-\\+" + LATIN_ACCENTS_CHARS + CYRILLIC_CHARS + "]|(?:" +
+      "[a-z0-9=_#/\\-\\+" + LATIN_ACCENTS_CHARS + CYRILLIC_CHARS + URL_UNICODE_CHARS + "]|(?:" +
           URL_BALANCED_PARENS + ")";
 
   private static final String URL_VALID_PATH = "(?:" +

--- a/java/src/test/java/com/twitter/twittertext/ExtractorTest.java
+++ b/java/src/test/java/com/twitter/twittertext/ExtractorTest.java
@@ -377,6 +377,18 @@ public class ExtractorTest extends TestCase {
     assertTrue("Should not extract URLs w/o protocol", extractor.extractURLs(text).isEmpty());
   }
 
+
+  public void testUrlWithUnicode() {
+    final String text = "http://www.詹姆斯.com http://www.詹姆斯.com/詹姆斯";
+    assertList("Failed to extract URLs with unicode",
+        new String[]{"http://www.詹姆斯.com", "http://www.詹姆斯.com/詹姆斯"},
+        extractor.extractURLs(text));
+
+    final String text1 = "https://简体中文.winshipway.com/good/";
+    assertList("Failed to extract URLs with unicode",
+        new String[]{"https://简体中文.winshipway.com/good/"},
+        extractor.extractURLs(text1));
+  }
   /**
    * Helper method for asserting that the List of extracted Strings match the expected values.
    *


### PR DESCRIPTION
Problem

The current Java version of this library has a limitation where it fails to recognize URLs containing Unicode characters. This is despite the fact that such URLs are supported by browsers and can be registered and used effectively. For instance, URLs like "http://www.詹姆斯.com/詹姆斯" are not identified as valid URLs. This issue arises from Java's inability to recognize Unicode characters as valid components in domain names and paths..

Solution

To address this issue, I have enhanced the regular expressions used for URL validation in the Java code. Specifically, I have incorporated the Unicode regex \p{L} and \p{M} into the regular expressions that validate the domain name and path of the URL. This modification ensures that the library can now correctly identify and validate URLs containing Unicode characters.
Result

With these changes, the library can now correctly identify URLs that include Unicode characters in their domain name or path as valid URLs. For example, a URL like "http://www.詹姆斯.com/詹姆斯" will now be correctly identified as a valid URL. This enhancement broadens the range of URLs that the library can recognize and validate, aligning it more closely with the behavior of modern web browsers.