### PR TITLE
fix: merge parseTweet options correctly.

### DIFF
--- a/js/src/parseTweet.js
+++ b/js/src/parseTweet.js
@@ -28,7 +28,12 @@ import urlHasHttps from './regexp/urlHasHttps';
  * displayRangeEnd {int} end index of display text (inclusive) in utf16
  */
 const parseTweet = function(text = '', options = configs.defaults) {
-  const mergedOptions = Object.keys(options).length ? options : configs.defaults;
+  // Merge the provided options with the defaults
+  const mergedOptions = {
+    ...configs.defaults,
+    ...options
+  };
+  
   const { defaultWeight, emojiParsingEnabled, scale, maxWeightedTweetLength, transformedURLLength } = mergedOptions;
   const normalizedText = typeof String.prototype.normalize === 'function' ? text.normalize() : text;
 


### PR DESCRIPTION
The existing implementation overrides the default options with the new ones if provided. In that case, if partial options are provided, this can lead to unexpected errors (Null values in return object) because default values are all reset.

Problem

The existing implementation overrides the default options with the new ones if provided. In that case, if partial options are provided, this can lead to unexpected errors (Null values in return object) because default values are all reset.

Solution

Merge correctly such that partial options provided are merged with correct defaults keeping the output sane. 

Result

fixes the parseTweet function when partial options are provided.